### PR TITLE
Add new menus

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,5 @@
 {
     "extends": ["airbnb", "prettier"],
-    "parser": "babel-eslint",
     "parserOptions": {
       "ecmaVersion": 8,
       "ecmaFeatures": {
@@ -43,27 +42,8 @@
       "space-before-function-paren": 0,
       "comma-dangle": 0,
       "max-len": 0,
-      "import/extensions": 0,
-      "import/no-extraneous-dependencies": [
-        "error",
-        {
-          "devDependencies": true
-        }
-      ],
-      "import/prefer-default-export": 0,
       "no-underscore-dangle": 0,
       "consistent-return": 0,
-      "react/display-name": 1,
-      "react/react-in-jsx-scope": 0,
-      "react/forbid-prop-types": 0,
-      "react/no-unescaped-entities": 0,
-      "react/prefer-stateless-function": 0,
-      "react/jsx-filename-extension": [
-        1,
-        {
-          "extensions": [".js", ".jsx"]
-        }
-      ],
       "radix": 0,
       "no-shadow": [
         2,
@@ -79,22 +59,7 @@
           "avoidEscape": true,
           "allowTemplateLiterals": true
         }
-      ],
-      "prettier/prettier": [
-        "error",
-        {
-          "trailingComma": "es5",
-          "singleQuote": true,
-          "printWidth": 120
-        }
-      ],
-      "jsx-a11y/href-no-hash": "off",
-      "jsx-a11y/anchor-is-valid": [
-        "warn",
-        {
-          "aspects": ["invalidHref"]
-        }
       ]
     },
-    "plugins": ["eslint-plugin-html", "prettier", "import"]
+    "plugins": ["prettier"]
   }

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,8 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        node: [8, 10, 12]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node: [8]
+        os: [macOS-latest]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    name: Test on node ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node: [8, 10, 12]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: https://registry.npmjs.org
+      - name: install
+        run: npm install
+      - name: lint
+        run: npm run lint
+      - name: test
+        run: npm test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: build
 
 on: [push]
 

--- a/__test__/__mocks__/axios.js
+++ b/__test__/__mocks__/axios.js
@@ -1,8 +1,17 @@
 const fs = require('fs');
 const path = require('path');
 
-const data = fs.readFileSync(path.resolve(__dirname, '../fixtures/werdino.html'), 'utf8');
+const axios = jest.genMockFromModule('axios');
 
-module.exports = {
-    get: jest.fn(() => Promise.resolve({ data }))
-}
+const get = jest.fn((url) => {
+    if (url && url.includes('bkw-atrium')) {
+        const atriumData = fs.readFileSync(path.resolve(__dirname, '../fixtures/bkw-atrium.html'), 'utf8');
+        return Promise.resolve({ data: atriumData });
+    }
+    const werdinoData = fs.readFileSync(path.resolve(__dirname, '../fixtures/werdino.html'), 'utf8');
+    return Promise.resolve({ data: werdinoData });
+});
+
+axios.get = get;
+
+module.exports = axios;

--- a/__test__/__mocks__/axios.js
+++ b/__test__/__mocks__/axios.js
@@ -4,12 +4,12 @@ const path = require('path');
 const axios = jest.genMockFromModule('axios');
 
 const get = jest.fn((url) => {
-    if (url && url.includes('bkw-atrium')) {
-        const atriumData = fs.readFileSync(path.resolve(__dirname, '../fixtures/bkw-atrium.html'), 'utf8');
-        return Promise.resolve({ data: atriumData });
-    }
-    const werdinoData = fs.readFileSync(path.resolve(__dirname, '../fixtures/werdino.html'), 'utf8');
-    return Promise.resolve({ data: werdinoData });
+	if (url && url.includes('bkw-atrium')) {
+    const atriumData = fs.readFileSync(path.resolve(__dirname, '../fixtures/bkw-atrium.html'), 'utf8');
+    return Promise.resolve({ data: atriumData });
+  }
+  const werdinoData = fs.readFileSync(path.resolve(__dirname, '../fixtures/werdino.html'), 'utf8');
+	return Promise.resolve({ data: werdinoData });
 });
 
 axios.get = get;

--- a/__test__/bkw-atrium.spec.js
+++ b/__test__/bkw-atrium.spec.js
@@ -1,0 +1,48 @@
+const fn = require('../helpers/bkw-atrium.js');
+
+jest.mock('axios');
+
+test('exports a promise with menu data', () => {
+  expect.assertions(2);
+  return fn('bkw-atrium').then(data => {
+    console.log({data});
+    expect(data.date).toBe('13.12.');
+    expect(Object.keys(data.meals)).toMatchObject([
+      'Herzlichen Dank',
+      'Paniertes Tofuschnitzel',
+      'Ghackets und Hörnli',
+      'Hot Komponenten Salatbuffet',
+    ]);
+  });
+});
+
+test('menu data', () => {
+  expect.assertions(10);
+  return fn('bkw-atrium').then(data => {
+    console.log(JSON.stringify(data, null, 2));
+
+    const bmeal = data.meals['Herzlichen Dank'];
+
+    expect(bmeal.title).toBe('Herzlichen Dank');
+    expect(bmeal.description).toBe('für Ihre Treue. Wir wünschen Ihnen ein schönes Wochenende. Ihr atrium-Team');
+    expect(bmeal.provenance).toBe('');
+    expect(bmeal.prices.length).toBe(0);
+
+    const gmeal = data.meals['Ghackets und Hörnli'];
+
+    expect(gmeal.title).toBe('Ghackets und Hörnli');
+    expect(gmeal.description).toBe('mit Rindfleischsauce, Reibkäse und Apfelmus oder Menusalat Add on: gebackene Zwiebelringe CHF 2.00');
+    expect(Array.isArray(gmeal.prices)).toBe(true);
+    expect(gmeal.prices[0]).toBe('9.50 CHF');
+    expect(gmeal.prices[1]).toBe('13.50 CHF');
+    expect(gmeal.provenance).toBe('Rind, Schweiz');
+  });
+});
+
+test('find the vegetarian label', () => {
+  expect.assertions(1);
+  return fn('bkw-atrium').then(data => {
+    const vmeal = data.meals['Paniertes Tofuschnitzel'];
+    expect(vmeal.vegetarian).toBe(true);
+  });
+});

--- a/__test__/bkw-atrium.spec.js
+++ b/__test__/bkw-atrium.spec.js
@@ -5,7 +5,6 @@ jest.mock('axios');
 test('exports a promise with menu data', () => {
   expect.assertions(2);
   return fn('bkw-atrium').then(data => {
-    console.log({data});
     expect(data.date).toBe('13.12.');
     expect(Object.keys(data.meals)).toMatchObject([
       'Herzlichen Dank',
@@ -19,8 +18,6 @@ test('exports a promise with menu data', () => {
 test('menu data', () => {
   expect.assertions(10);
   return fn('bkw-atrium').then(data => {
-    console.log(JSON.stringify(data, null, 2));
-
     const bmeal = data.meals['Herzlichen Dank'];
 
     expect(bmeal.title).toBe('Herzlichen Dank');
@@ -40,9 +37,12 @@ test('menu data', () => {
 });
 
 test('find the vegetarian label', () => {
-  expect.assertions(1);
+  expect.assertions(2);
   return fn('bkw-atrium').then(data => {
     const vmeal = data.meals['Paniertes Tofuschnitzel'];
     expect(vmeal.vegetarian).toBe(true);
+
+    const bmeal = data.meals['Herzlichen Dank'];
+    expect(bmeal.vegetarian).toBe(false);
   });
 });

--- a/__test__/bkw-atrium.spec.js
+++ b/__test__/bkw-atrium.spec.js
@@ -28,7 +28,9 @@ test('menu data', () => {
     const gmeal = data.meals['Ghackets und Hörnli'];
 
     expect(gmeal.title).toBe('Ghackets und Hörnli');
-    expect(gmeal.description).toBe('mit Rindfleischsauce, Reibkäse und Apfelmus oder Menusalat Add on: gebackene Zwiebelringe CHF 2.00');
+    expect(gmeal.description).toBe(
+      'mit Rindfleischsauce, Reibkäse und Apfelmus oder Menusalat Add on: gebackene Zwiebelringe CHF 2.00'
+    );
     expect(Array.isArray(gmeal.prices)).toBe(true);
     expect(gmeal.prices[0]).toBe('9.50 CHF');
     expect(gmeal.prices[1]).toBe('13.50 CHF');

--- a/__test__/eurest.spec.js
+++ b/__test__/eurest.spec.js
@@ -1,4 +1,4 @@
-const fn = require('../helpers/werdino.js');
+const fn = require('../helpers/eurest');
 
 jest.mock('axios');
 

--- a/__test__/fixtures/bkw-atrium.html
+++ b/__test__/fixtures/bkw-atrium.html
@@ -1,0 +1,1213 @@
+<!DOCTYPE html>
+<html class="csscalc cookies history no-touchevents pointerevents video cssanimations flexbox csstransforms supports csstransforms3d csstransitions sessionstorage inlinesvg no-android no-androidnative no-blackberry no-playbook no-kindle no-windowsphone no-iphone no-ipad no-ipod no-ios no-ios3 no-ios4 no-ios5 no-ios6 no-ios7 no-ios8 no-ios9 no-oldios no-lt-ios6 no-lt-ios7 no-lt-ios8 no-lt-ios9 no-lt-ios10 mac no-win no-linux no-mobile">
+    <head>
+
+    <meta charset="utf-8">
+
+    
+    
+    
+    <title>Menuplan - BKW Atrium</title>
+    <meta name="generator" content="TYPO3 CMS">
+    <meta property="og:type" content="website">
+    <meta name="viewport" content="width=device-width, user-scalable=yes, minimum-scale=1.0, initial-scale=1.0">
+    <meta name="msapplication-tap-highlight" content="no">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="robots" content="index,follow">
+    <meta name="description" content="Abwechslungsreiche und feine Mittagsmenus ✔ grosses Salatbuffet ✔ Täglich frisch zubereitet: Montag bis Freitag ➜ JETZT in Bern GENIESSEN − Ihr Restaurant mit Take-Away-Angebot.">
+    <meta property="og:url" content="https://bkw-bern.sv-restaurant.ch/de/menuplan/">
+    <meta property="og:title" content="Menuplan">
+    <meta property="og:description" content="Abwechslungsreiche und feine Mittagsmenus ✔ grosses Salatbuffet ✔ Täglich frisch zubereitet: Montag bis Freitag ➜ JETZT in Bern GENIESSEN − Ihr Restaurant mit Take-Away-Angebot.">
+    <meta property="og:site_name" content="BKW Atrium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:description" content="Abwechslungsreiche und feine Mittagsmenus ✔ grosses Salatbuffet ✔ Täglich frisch zubereitet: Montag bis Freitag ➜ JETZT in Bern GENIESSEN − Ihr Restaurant mit Take-Away-Angebot.">
+    
+    
+    <link rel="stylesheet" type="text/css" href="/typo3temp/compressor/merged-b1ed12094a23f3f70a092d838d3b9390-f1389d9827c7168c5a819eabd4ec3c56.css.gzip?1574424216" media="all">
+    
+    
+    
+    
+                <script type="text/javascript" id="www-widgetapi-script" src="https://s.ytimg.com/yts/jsbin/www-widgetapi-vflBs9Ibw/www-widgetapi.js" async=""></script><script src="//www.youtube.com/iframe_api"></script><script src="https://www.youtube.com/iframe_api"></script><script>
+                    var reqBaseUrl="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/", netvPageOptions = { 'templateRoot' : '/typo3conf/ext/netv_svm_template/Resources/Public/dist/' };;
+                </script><script src="/typo3temp/compressor/controller-f3059d36064c8c2c7e301b5ddb663be7.js.gzip?1572438104" type="text/javascript"></script><link type="text/css" rel="stylesheet" href="https://fast.fonts.net/t/1.css?apiType=css&amp;projectid=19d2676c-b1fd-4c06-b6bc-0d6b66e3aaa9">
+    
+    
+    
+    <script type="text/javascript">var requiredModules = ["jquery","jquery.shariff","jquery.googleanalytics"];</script>
+    <script data-main="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/app.js?1575289883" src="/typo3conf/ext/netv_requirejs/Resources/Public/dist/js/lib/vendor/require.js" async=""></script>
+                <!--[if lte IE 9]>
+                    <link rel="stylesheet" href="https://fast.fonts.net/t/1.css?apiType=css&projectid=19d2676c-b1fd-4c06-b6bc-0d6b66e3aaa9" media="all">
+                <![endif]--><meta itemprop="name" content="Menuplan - BKW Atrium">
+    <link rel="icon" type="image/png" sizes="16x16" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/favicon/favicon-16x16.png?1504685003">
+    <link rel="icon" type="image/png" sizes="32x32" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/favicon/favicon-32x32.png?1504685003">
+    <link rel="icon" type="image/png" sizes="96x96" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/favicon/favicon-96x96.png?1504685003">
+    <link rel="shortcut icon" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/favicon/favicon.ico?1504685003">
+    <link rel="apple-touch-icon-precomposed" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-60x60-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-72x72-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-76x76-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-114x114-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-120x120-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-144x144-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-152x152-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="180x180" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-180x180-precomposed.png?1504685003">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/apple-touch-icons/apple-touch-icon-192x192-precomposed.png?1504685003">
+    <link rel="manifest" href="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/android/manifest.json?1504685003">
+    <meta name="msapplication-config" content="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/fav-touch/default/mstile/browserconfig.xml?1504685003">
+    <meta itemprop="description" content="Abwechslungsreiche und feine Mittagsmenus ✔ grosses Salatbuffet ✔ Täglich frisch zubereitet: Montag bis Freitag ➜ JETZT in Bern GENIESSEN − Ihr Restaurant mit Take-Away-Angebot.">
+    <script type="text/javascript">requiredModules.push("jquery.slick.controller");requiredModules.push("jquery.overlay");requiredModules.push("jquery.resizeTitles");</script>
+    <script type="text/javascript">requiredModules.push("jquery.vote-menu-form");</script>
+    
+    <script type="text/javascript">requiredModules.push("jquery.newsletter");</script>
+    <script type="text/javascript">requiredModules.push("jquery.menuplan");</script>
+    <script type="text/javascript">requiredModules.push("iframe-resizer");</script>
+    <script type="text/javascript">requiredModules.push("iframeresize");</script>
+    <script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/app.js?1575289883" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/app.js?1575289883"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="app/main" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/../app/main.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/vendor/jquery-2.1.4.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="iframe-resizer" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/vendor/iframeResizer.min.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.slick" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/vendor/jquery.slick.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="ga" src="https://www.google-analytics.com/analytics.js"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="youtubePlayer" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/vendor/youtubePlayer.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="iframeresize" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/iframeresize.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.shariff" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.shariff.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.overlay" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.overlay.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.resizeTitles" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.resizeTitles.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.vote-menu-form" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.vote-menu-form.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.newsletter" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.newsletter.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.menuplan" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.menuplan.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="lunametrics-youtube.gtm" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/vendor/lunametrics-youtube.gtm.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.slick.controller" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.slick.controller.js?v=134"></script><script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="jquery.googleanalytics" src="/typo3conf/ext/netv_svm_template/Resources/Public/dist/js/lib/plugins/jquery.googleanalytics.js?v=134"></script></head>
+    <body class="de " id="pageid-15628">
+    
+    <div id="browsermessages"><!--[if lte IE 9]><div class="browsermessage nojs"><div class="items"><div class="items-row"><div class="row-item icon"></div><div class="row-item text"><div class="header">Website nur eingeschränkt nutzbar</div><div class="message">Sie surfen mit einem veralteten Webbrowser</div></div></div></div></div><![endif]--><noscript><div class="browsermessage"><div class="items"><div class="items-row"><div class="row-item icon"></div><div class="row-item text"><div class="header" data-text="Website nur eingeschränkt nutzbar"></div><div class="message" data-text="Bitte aktivieren Sie Javascript, um die Website uneingeschränkt nutzen zu können."></div></div></div></div></div></noscript><div class="browsermessage"><div class="items"><div class="items-row cookies"><div class="row-item icon"></div><div class="row-item text"><div class="header" data-text="Website nur eingeschränkt nutzbar"></div><div class="message" data-text="Bitte aktivieren Sie Cookies, um die Website uneingeschränkt nutzen zu können."></div></div></div></div></div></div><div id="l-pagewrapper"><div id="l-container"><header id="l-header" class="l-header"><div id="navbar"><div class="l-constrained l-wide"><div class="logo-wrap"><a href="/de/menuplan/"><img src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/logos/default/logo-header.svg" alt="SV Restaurant"></a></div><div class="name-wrap"><a href="/de/menuplan/">
+                        BKW Atrium
+                    </a></div><div class="nav-trigger-wrap"><a target="_self" onclick="netvLib.mainnav.trigger(this, event);"><span class="lines"></span></a></div></div></div><div id="header-content"><!-- this plugin registered jquery.slick.controller,jquery.overlay,jquery.resizeTitles for RequireJS --><!-- this plugin registered jquery.vote-menu-form for RequireJS --><div class="slideshow"><img class="preloader" src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/preloader.svg" alt="Laden..."><div class="slick-slider slick-initialized slick-dotted"><!-- HEADERCAMPAINS (from fileadmin/content/headercampaigns) -->
+    <!-- BANNERS MENUOFDESIRE WUNSCHMENU (RMADMIN) --><!-- BANNERADS (CMS global, prio >= 80) -->
+    
+    
+            
+        
+    <!-- BANNERADS (Fresh & healthy FRISCH UND GESUND) -->
+        
+            <div aria-live="polite" class="slick-list draggable" style="padding: 0px 50px;"><div class="slick-track" style="opacity: 1; width: 20000px; transform: translate3d(-3842px, 0px, 0px);" role="listbox"><div class="single-slide slick-slide slick-cloned" data-slick-index="-2" aria-hidden="true" tabindex="-1">
+                        
+                            
+                            
+                                
+    
+    <picture class="background">
+        <source srcset="/fileadmin/_processed_/e/9/csm_winter_winterzauber_guetzli_desktop%402x_2e05168c71.jpg, /fileadmin/_processed_/e/9/csm_winter_winterzauber_guetzli_desktop%402x_16d3055329.jpg 2x" media="(min-width: 769px)">
+    
+        
+                <source srcset="/fileadmin/_processed_/b/b/csm_winter_winterzauber_guetzli_mobile%402x_62e116ac2a.jpg, /fileadmin/_processed_/b/b/csm_winter_winterzauber_guetzli_mobile%402x_330912e48d.jpg 2x" media="(max-width: 768px)">
+            
+        <img src="/fileadmin/_processed_/e/9/csm_winter_winterzauber_guetzli_desktop%402x_2e05168c71.jpg" alt="Winterzauber">
+    </picture>
+    <div class="slide-content-wrap">
+        <div class="slide-content type2" style="background-color: rgba(0,0,0,.4);">
+            
+                <h3 style="font-size: 36px;">Winterzauber</h3>
+            
+            
+                <p>
+                    Geniessen Sie jetzt wieder unsere hausgemachten Guetzli<br>
+    und feinste Schweizer Weihnachtsschokolade!
+                </p>
+            
+            
+        </div>
+    </div>
+    
+                            
+                            
+                        
+                    </div><a href="/de/catering/" target="_self" class="single-slide slick-slide slick-cloned slick-center" data-slick-index="-1" aria-hidden="true" tabindex="-1">
+                        
+                            
+                            
+                                
+    
+    <picture class="background">
+        <source srcset="/fileadmin/_processed_/3/b/csm_ganzjahr_apero_desktop%402x_891a758632.jpg, /fileadmin/_processed_/3/b/csm_ganzjahr_apero_desktop%402x_da4148cf42.jpg 2x" media="(min-width: 769px)">
+    
+        
+                <source srcset="/fileadmin/_processed_/c/7/csm_ganzjahr_apero_mobile%402x_432c4f496d.jpg, /fileadmin/_processed_/c/7/csm_ganzjahr_apero_mobile%402x_81e4d9ad40.jpg 2x" media="(max-width: 768px)">
+            
+        <img src="/fileadmin/_processed_/3/b/csm_ganzjahr_apero_desktop%402x_891a758632.jpg" alt="Catering">
+    </picture>
+    <div class="slide-content-wrap">
+        <div class="slide-content type2" style="background-color: rgba(0,0,0,.4)" )}="">
+            
+                <h3 style="font-size: 36px;">Catering</h3>
+            
+            
+                <p>
+                    Sei es für Ihren Apéro, Stehlunch oder feierlichen Anlass
+                </p>
+            
+            
+                <span class="separator"></span>
+                <span class="additional">
+                    Zum Catering Angebot
+                </span>
+            
+        </div>
+    </div>
+    
+                            
+                            
+                        
+                    </a><a href="/de/frisch-gesund/" class="single-slide slick-slide" data-slick-index="0" aria-hidden="true" tabindex="-1" role="option" aria-describedby="slick-slide00">
+                
+        <picture class="background">
+            <source srcset="/fileadmin/_processed_/8/9/csm_1540x590_12-Dez_Nudeln_f27c5f9ec6.jpg, /fileadmin/_processed_/8/9/csm_1540x590_12-Dez_Nudeln_cbcd449822.jpg 2x" media="(min-width: 769px)">
+            
+                    <source srcset="/fileadmin/_processed_/0/2/csm_570x640_12-Dez_Nudeln_56526639b7.jpg, /fileadmin/_processed_/0/2/csm_570x640_12-Dez_Nudeln_08d24a9dd7.jpg 2x" media="(max-width: 768px)">
+                
+            <img src="/fileadmin/_processed_/8/9/csm_1540x590_12-Dez_Nudeln_f27c5f9ec6.jpg" alt="Frisch &amp; gesund">
+        </picture>
+    
+    <div class="slide-content-wrap">
+        <div class="slide-content type1" style="background-color: rgba(89, 156, 46, .7);">
+            <h3 style="font-size: 36px;">Frisch &amp; gesund</h3>
+            <span class="separator"></span>
+            <span class="additional">Mehr erfahren</span>
+        </div>
+    </div>
+            </a><div class="single-slide slick-slide" data-slick-index="1" aria-hidden="true" tabindex="-1" role="option" aria-describedby="slick-slide01">
+                        
+                            
+                            
+                                
+    
+    <picture class="background">
+        <source srcset="/fileadmin/_processed_/8/3/csm_special_schnitzel_desktop%402x_9d1e61a22c.jpg, /fileadmin/_processed_/8/3/csm_special_schnitzel_desktop%402x_0f444aaf55.jpg 2x" media="(min-width: 769px)">
+    
+        
+                <source srcset="/fileadmin/_processed_/2/9/csm_special_schnitzel_mobile%402x_1dffac5728.jpg, /fileadmin/_processed_/2/9/csm_special_schnitzel_mobile%402x_5bbb0451b8.jpg 2x" media="(max-width: 768px)">
+            
+        <img src="/fileadmin/_processed_/8/3/csm_special_schnitzel_desktop%402x_9d1e61a22c.jpg" alt="Schnitzeljagd">
+    </picture>
+    <div class="slide-content-wrap">
+        <div class="slide-content type2" style="background-color: rgba(0,0,0,.4);">
+            
+                <h3 style="font-size: 36px;">Schnitzeljagd</h3>
+            
+            
+                <p>
+                    Krustig und gluschtig. <br>
+    Jeden letzten Freitag<br>
+    im Monat!
+                </p>
+            
+            
+        </div>
+    </div>
+    
+                            
+                            
+                        
+                    </div><div class="single-slide slick-slide" data-slick-index="2" aria-hidden="true" tabindex="-1" role="option" aria-describedby="slick-slide02">
+                        
+                            
+                            
+                                
+    
+    <picture class="background">
+        <source srcset="/fileadmin/_processed_/e/9/csm_winter_winterzauber_guetzli_desktop%402x_2e05168c71.jpg, /fileadmin/_processed_/e/9/csm_winter_winterzauber_guetzli_desktop%402x_16d3055329.jpg 2x" media="(min-width: 769px)">
+    
+        
+                <source srcset="/fileadmin/_processed_/b/b/csm_winter_winterzauber_guetzli_mobile%402x_62e116ac2a.jpg, /fileadmin/_processed_/b/b/csm_winter_winterzauber_guetzli_mobile%402x_330912e48d.jpg 2x" media="(max-width: 768px)">
+            
+        <img src="/fileadmin/_processed_/e/9/csm_winter_winterzauber_guetzli_desktop%402x_2e05168c71.jpg" alt="Winterzauber">
+    </picture>
+    <div class="slide-content-wrap">
+        <div class="slide-content type2" style="background-color: rgba(0,0,0,.4);">
+            
+                <h3 style="font-size: 36px;">Winterzauber</h3>
+            
+            
+                <p>
+                    Geniessen Sie jetzt wieder unsere hausgemachten Guetzli<br>
+    und feinste Schweizer Weihnachtsschokolade!
+                </p>
+            
+            
+        </div>
+    </div>
+    
+                            
+                            
+                        
+                    </div><a href="/de/catering/" target="_self" class="single-slide slick-slide slick-current slick-active slick-center" data-slick-index="3" aria-hidden="false" tabindex="-1" role="option" aria-describedby="slick-slide03">
+                        
+                            
+                            
+                                
+    
+    <picture class="background">
+        <source srcset="/fileadmin/_processed_/3/b/csm_ganzjahr_apero_desktop%402x_891a758632.jpg, /fileadmin/_processed_/3/b/csm_ganzjahr_apero_desktop%402x_da4148cf42.jpg 2x" media="(min-width: 769px)">
+    
+        
+                <source srcset="/fileadmin/_processed_/c/7/csm_ganzjahr_apero_mobile%402x_432c4f496d.jpg, /fileadmin/_processed_/c/7/csm_ganzjahr_apero_mobile%402x_81e4d9ad40.jpg 2x" media="(max-width: 768px)">
+            
+        <img src="/fileadmin/_processed_/3/b/csm_ganzjahr_apero_desktop%402x_891a758632.jpg" alt="Catering">
+    </picture>
+    <div class="slide-content-wrap">
+        <div class="slide-content type2" style="background-color: rgba(0,0,0,.4)" )}="">
+            
+                <h3 style="font-size: 36px;">Catering</h3>
+            
+            
+                <p>
+                    Sei es für Ihren Apéro, Stehlunch oder feierlichen Anlass
+                </p>
+            
+            
+                <span class="separator"></span>
+                <span class="additional">
+                    Zum Catering Angebot
+                </span>
+            
+        </div>
+    </div>
+    
+                            
+                            
+                        
+                    </a><a href="/de/frisch-gesund/" class="single-slide slick-slide slick-cloned" data-slick-index="4" aria-hidden="true" tabindex="-1">
+                
+        <picture class="background">
+            <source srcset="/fileadmin/_processed_/8/9/csm_1540x590_12-Dez_Nudeln_f27c5f9ec6.jpg, /fileadmin/_processed_/8/9/csm_1540x590_12-Dez_Nudeln_cbcd449822.jpg 2x" media="(min-width: 769px)">
+            
+                    <source srcset="/fileadmin/_processed_/0/2/csm_570x640_12-Dez_Nudeln_56526639b7.jpg, /fileadmin/_processed_/0/2/csm_570x640_12-Dez_Nudeln_08d24a9dd7.jpg 2x" media="(max-width: 768px)">
+                
+            <img src="/fileadmin/_processed_/8/9/csm_1540x590_12-Dez_Nudeln_f27c5f9ec6.jpg" alt="Frisch &amp; gesund">
+        </picture>
+    
+    <div class="slide-content-wrap">
+        <div class="slide-content type1" style="background-color: rgba(89, 156, 46, .7);">
+            <h3 style="font-size: 36px;">Frisch &amp; gesund</h3>
+            <span class="separator"></span>
+            <span class="additional">Mehr erfahren</span>
+        </div>
+    </div>
+            </a><div class="single-slide slick-slide slick-cloned" data-slick-index="5" aria-hidden="true" tabindex="-1">
+                        
+                            
+                            
+                                
+    
+    <picture class="background">
+        <source srcset="/fileadmin/_processed_/8/3/csm_special_schnitzel_desktop%402x_9d1e61a22c.jpg, /fileadmin/_processed_/8/3/csm_special_schnitzel_desktop%402x_0f444aaf55.jpg 2x" media="(min-width: 769px)">
+    
+        
+                <source srcset="/fileadmin/_processed_/2/9/csm_special_schnitzel_mobile%402x_1dffac5728.jpg, /fileadmin/_processed_/2/9/csm_special_schnitzel_mobile%402x_5bbb0451b8.jpg 2x" media="(max-width: 768px)">
+            
+        <img src="/fileadmin/_processed_/8/3/csm_special_schnitzel_desktop%402x_9d1e61a22c.jpg" alt="Schnitzeljagd">
+    </picture>
+    <div class="slide-content-wrap">
+        <div class="slide-content type2" style="background-color: rgba(0,0,0,.4);">
+            
+                <h3 style="font-size: 36px;">Schnitzeljagd</h3>
+            
+            
+                <p>
+                    Krustig und gluschtig. <br>
+    Jeden letzten Freitag<br>
+    im Monat!
+                </p>
+            
+            
+        </div>
+    </div>
+    
+                            
+                            
+                        
+                    </div></div></div>
+        
+    
+    
+    
+    <!-- BANNERS RMADMIN -->
+        
+            
+                    
+                
+        
+    
+        
+            
+                    
+                
+        
+    
+    <!-- BANNERADS (CMS global, prio < 80) -->
+    
+    
+            
+        
+    <!-- BANNERADS (CMS local) -->
+        
+            
+                    
+                
+        
+    
+    </div><div class="slides-nav-container" role="toolbar"><ul class="slick-dots" role="tablist" style="display: block;"><li class="" aria-hidden="true" role="presentation" aria-selected="true" aria-controls="navigation00" id="slick-slide00"><button type="button" data-role="none" role="button" tabindex="0">1</button></li><li aria-hidden="true" role="presentation" aria-selected="false" aria-controls="navigation01" id="slick-slide01" class=""><button type="button" data-role="none" role="button" tabindex="0">2</button></li><li aria-hidden="true" role="presentation" aria-selected="false" aria-controls="navigation02" id="slick-slide02" class=""><button type="button" data-role="none" role="button" tabindex="0">3</button></li><li aria-hidden="false" role="presentation" aria-selected="false" aria-controls="navigation03" id="slick-slide03" class="slick-active"><button type="button" data-role="none" role="button" tabindex="0">4</button></li></ul></div></div></div></header><div id="mainnav"><div class="inner"><nav class="main"><ul class="no-bullets"><li><a href="/de/menuplan/" target="_self" class="act">Menuplan</a></li><li><a href="/de/catering/" target="_self">Catering</a></li><li><a href="/de/frisch-gesund/" target="_self">Frisch &amp; Gesund</a></li><li><a href="/de/ueber-uns/" target="_self">Über uns</a></li></ul></nav><nav class="meta"><ul class="no-bullets"><li><a href="/de/feedback/" target="_self">Feedback</a></li><li><a href="/de/kontakt/" target="_self">Kontakt</a></li><li><a href="/de/disclaimer/" target="_self">Disclaimer</a></li><li><a href="/de/datenschutzerklaerung/" target="_self">Datenschutzerklärung</a></li></ul></nav><nav class="mobile"><ul class="switch-restaurant no-bullets"><li><a href="#" onclick="netvLib.restaurantSwitcher.trigger(this, event);">Weitere Restaurants</a></li></ul></nav></div><nav class="parent" style="position: fixed;"><ul class="no-bullets"><li><a href="http://www.sv-restaurant.ch/de/" target="_blank">www.sv-restaurant.ch</a></li></ul></nav></div><div id="restaurant-switcher"><a href="#" onclick="netvLib.restaurantSwitcher.trigger(this, event);">Weitere Restaurants</a></div><div id="restaurant-switcher-overlay"><a href="#" class="restaurant-switcher-close" onclick="netvLib.restaurantSwitcher.trigger(this, event);"><i></i></a><div class="list-wrap"><div class="title">
+                            Gastronomie BKW
+                        </div><ul class="no-bullets"><li><a href="https://bkw-ostermundigen.sv-restaurant.ch/menuplan/">BKW Casamo</a></li></ul></div><div class="map-wrap"><div class="title">
+                            Öffentliche Restaurants in Ihrer Umgebung
+                        </div><div class="map"><div class="googlemap" data-ajax-url="/de/menuplan/persrest-data.json"></div></div></div></div><main id="l-main" itemprop="mainContentOfPage"><div class="l-constrained l-full l-content"><div class="content content-list-"><a class="anchor" id="c80756"></a>
+    
+    
+    
+    
+    <!-- this plugin registered jquery.newsletter for RequireJS -->
+    <!-- this plugin registered jquery.menuplan for RequireJS -->
+    
+    <div class="menu-plan-wrap">
+        <div class="l-constrained l-special">
+            <div class="coe pagetitle">
+                <h1 class="title">Menuplan</h1>
+            </div>
+    
+            
+    
+            
+                <input id="mp-tab1" name="mp-tab" value="" checked="" type="radio">
+            
+                <input id="mp-tab2" name="mp-tab" value="" type="radio">
+            
+                <input id="mp-tab3" name="mp-tab" value="" type="radio">
+            
+                <input id="mp-tab4" name="mp-tab" value="" type="radio">
+            
+                <input id="mp-tab5" name="mp-tab" value="" type="radio">
+            
+    
+            <div class="day-nav">
+                
+                    <ul class="no-bullets is-horizontal">
+                        
+                            <li>
+                                <label for="mp-tab1">
+                                    <span class="day">Fr</span>
+                                    <span class="date">13.12.</span>
+                                </label>
+                            </li>
+                        
+                            <li>
+                                <label for="mp-tab2">
+                                    <span class="day">Mo</span>
+                                    <span class="date">16.12.</span>
+                                </label>
+                            </li>
+                        
+                            <li>
+                                <label for="mp-tab3">
+                                    <span class="day">Di</span>
+                                    <span class="date">17.12.</span>
+                                </label>
+                            </li>
+                        
+                            <li>
+                                <label for="mp-tab4">
+                                    <span class="day">Mi</span>
+                                    <span class="date">18.12.</span>
+                                </label>
+                            </li>
+                        
+                            <li>
+                                <label for="mp-tab5">
+                                    <span class="day">Do</span>
+                                    <span class="date">19.12.</span>
+                                </label>
+                            </li>
+                        
+                    </ul>
+                
+            </div>
+    
+            <div class="menu-plan-tabs">
+                
+                        
+                            <div id="menu-plan-tab1" class="menu-plan-grid" data-columns="2"><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Herzlichen Dank</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">für Ihre Treue.<br>
+    Wir wünschen Ihnen ein <br>
+    schönes Wochenende.<br>
+    <br>
+    Ihr atrium-Team</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Paniertes Tofuschnitzel</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Zitronengarnitur,<br>
+    Zartweizen und<br>
+    Gartenerbsen mit Minze</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                                <div class="menu-labels">
+                                                    
+                                                        
+            <span class="label label-vegetarian has-infobox">
+                <img class="onlyprint" src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/print/vegetarian.png" width="121" height="121" alt="">
+                <div class="label-info label-vegetarian ">
+                    <a class="close" href="#"><i class="ico-close"></i></a>
+                    <div class="inner">
+                        <p>Vegetarisch:<br>
+    Dieses Menu beinhaltet weder Fleisch noch Fisch.</p>
+                        
+                            
+                            
+                            
+                            
+                                
+                            
+                        
+                    </div>
+                </div>
+            </span>
+        
+                                                    
+                                                    
+                                                </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div></div><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Ghackets und Hörnli</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Rindfleischsauce,<br>
+    Reibkäse<br>
+    und Apfelmus oder Menusalat<br>
+    Add on:<br>
+    gebackene Zwiebelringe<br>
+    CHF 2.00</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Rind, Schweiz</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Hot Komponenten Salatbuffet</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Gemüse, Beilagen,<br>
+    Fleisch oder Fisch<br>
+    per 100g</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">2.40</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">3.20</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div></div></div>
+                        
+                            <div id="menu-plan-tab2" class="menu-plan-grid" data-columns="2"><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">ASC Lachstranche</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Limettenmayonnaise,<br>
+    Cranberry-Quinoa <br>
+    und geschmorter Lattich<br>
+    <br>
+    <br>
+    <br>
+    ...es het solang's het...</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">14.90</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">18.90</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Lachs, Zucht, Norwegen</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Pilzrisotto</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit gebratenen Waldpilzen<br>
+    und Reibkäse<br>
+    <br>
+    Add on:<br>
+    gebackene Zwiebelringe CHF 2.00</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                                <div class="menu-labels">
+                                                    
+                                                        
+            <span class="label label-vegetarian has-infobox">
+                <img class="onlyprint" src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/print/vegetarian.png" width="121" height="121" alt="">
+                <div class="label-info label-vegetarian ">
+                    <a class="close" href="#"><i class="ico-close"></i></a>
+                    <div class="inner">
+                        <p>Vegetarisch:<br>
+    Dieses Menu beinhaltet weder Fleisch noch Fisch.</p>
+                        
+                            
+                            
+                            
+                            
+                                
+                            
+                        
+                    </div>
+                </div>
+            </span>
+        
+                                                    
+                                                    
+                                                </div>
+                                            
+                                            <span class="menu-provenance">Schwein, Schweiz</span>
+                                            
+                                        </div>
+                                    </div></div><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Beef con Castor</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Rinds­geschnetzeltes<br>
+    mit Rotwein-<br>
+    Gemüsesauce, <br>
+    Polenta und<br>
+    Blumenkohl mit Petersilie</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Rind, Schweiz</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Hot Komponenten Salatbuffet</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Gemüse, Beilagen,<br>
+    Fleisch oder Fisch<br>
+    per 100g</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">2.40</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">3.20</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div></div></div>
+                        
+                            <div id="menu-plan-tab3" class="menu-plan-grid" data-columns="2"><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Schweinsfilet-Medaillons<br>
+    im Kernmantel</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Whisky-Jus,<br>
+    Ebly<br>
+    und glasierten Karotten<br>
+    <br>
+    ...es het solang's het...</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">14.90</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">18.90</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Schwein, Schweiz</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Pizza Abscialti</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Tomatensauce, Mozzarella,<br>
+    Cipolotti, Peperoni und <br>
+    Chorizo</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Schwein, Schweiz</span>
+                                            
+                                        </div>
+                                    </div></div><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Bulgur Marrakesch</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Orientalisches Gemüsecurry<br>
+    mit Koriander<br>
+    Add on:<br>
+    2 Mini Samosas<br>
+    CHF 2.50</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                                <div class="menu-labels">
+                                                    
+                                                        
+            <span class="label label-vegetarian has-infobox">
+                <img class="onlyprint" src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/print/vegetarian.png" width="121" height="121" alt="">
+                <div class="label-info label-vegetarian ">
+                    <a class="close" href="#"><i class="ico-close"></i></a>
+                    <div class="inner">
+                        <p>Vegetarisch:<br>
+    Dieses Menu beinhaltet weder Fleisch noch Fisch.</p>
+                        
+                            
+                            
+                            
+                            
+                                
+                            
+                        
+                    </div>
+                </div>
+            </span>
+        
+                                                    
+                                                    
+                                                </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Hot Komponenten Salatbuffet</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Gemüse, Beilagen,<br>
+    Fleisch oder Fisch<br>
+    per 100g</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">2.40</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">3.20</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div></div></div>
+                        
+                            <div id="menu-plan-tab4" class="menu-plan-grid" data-columns="2"><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Poulet-Saltimbocca</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Salbeisauce,<br>
+    Galettini mediterrane<br>
+    und gebratenen Zucchetti</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.90</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">17.90</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Poulet, Schweiz</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Mein Lieblingsmenu</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Halbwertsei<br>
+    mit Senfsauce,<br>
+    Salzkartoffeln<br>
+    und gedünstetem Brokkoli</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                                <div class="menu-labels">
+                                                    
+                                                        
+            <span class="label label-vegetarian has-infobox">
+                <img class="onlyprint" src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/print/vegetarian.png" width="121" height="121" alt="">
+                <div class="label-info label-vegetarian ">
+                    <a class="close" href="#"><i class="ico-close"></i></a>
+                    <div class="inner">
+                        <p>Vegetarisch:<br>
+    Dieses Menu beinhaltet weder Fleisch noch Fisch.</p>
+                        
+                            
+                            
+                            
+                            
+                                
+                            
+                        
+                    </div>
+                </div>
+            </span>
+        
+                                                    
+                                                    
+                                                </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div></div><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Stillgelegtes Kalbsragout</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Thymiansauce,<br>
+    Spiralen<br>
+    und Kohlrabi mit Petersilie</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Kalb, Schweiz</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Hot Komponenten Salatbuffet</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Gemüse, Beilagen,<br>
+    Fleisch oder Fisch<br>
+    per 100g</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">2.40</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">3.20</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div></div></div>
+                        
+                            <div id="menu-plan-tab5" class="menu-plan-grid" data-columns="2"><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Cordon Bleu<br>
+    "Kräuterhexe"</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Zigeunerschinken<br>
+    und Cantadou, <br>
+    Texas frites<br>
+     und Erbsen-Maisgemüse<br>
+    Add on:<br>
+    1 Spiegelei CHF 1.50<br>
+    ...es het solang`s het...</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.90</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">17.90</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Schwein, Schweiz</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">MSC Fisch-Brennstäbli</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Tartarsauce,<br>
+    Wildreis und <br>
+    Rahmspinat</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance">Alaska-Seelachs, Wildfang, Nordwestpazifik</span>
+                                            
+                                        </div>
+                                    </div></div><div class="column size-1of2"><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">KKM­ler Käsespätzli</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">mit Rahmsauce,<br>
+    Käse, Röstzwiebeln<br>
+    und Apfelmus<br>
+    oder Menusalat<br>
+    Add on:<br>
+    Schinkenwürfel CHF 2.00</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">9.50</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">13.50</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                                <div class="menu-labels">
+                                                    
+                                                        
+            <span class="label label-vegetarian has-infobox">
+                <img class="onlyprint" src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/icons/print/vegetarian.png" width="121" height="121" alt="">
+                <div class="label-info label-vegetarian ">
+                    <a class="close" href="#"><i class="ico-close"></i></a>
+                    <div class="inner">
+                        <p>Vegetarisch:<br>
+    Dieses Menu beinhaltet weder Fleisch noch Fisch.</p>
+                        
+                            
+                            
+                            
+                            
+                                
+                            
+                        
+                    </div>
+                </div>
+            </span>
+        
+                                                    
+                                                    
+                                                </div>
+                                            
+                                            <span class="menu-provenance">Schwein, Schweiz</span>
+                                            
+                                        </div>
+                                    </div><div class="menu-item">
+                                        <div class="item-content">
+                                            
+                                            <h2 class="menu-title">Hot Komponenten Salatbuffet</h2>
+                                            <span class="divider"></span>
+                                            <p class="menu-description">Gemüse, Beilagen,<br>
+    Fleisch oder Fisch<br>
+    per 100g</p>
+                                            <div class="menu-prices prices-3">
+                                                
+                                                    <span class="price">
+                                                        <span class="val">2.40</span>
+                                                        <span class="desc">INT</span>
+                                                    </span>
+                                                
+                                                    <span class="price">
+                                                        <span class="val">3.20</span>
+                                                        <span class="desc">EXT</span>
+                                                    </span>
+                                                
+                                            </div>
+                                            
+                                            <span class="menu-provenance"></span>
+                                            
+                                        </div>
+                                    </div></div></div>
+                        
+                    
+            </div>
+    
+            <div class="menu-meta-nav">
+                <ul class="no-bullets is-horizontal">
+                    
+                        <li>
+                            <a href="/uploads/tx_netvsvgmenu_mbs5/20224100/2019W50-de_20224100.pdf" target="_blank">
+                                <i class="ico ico-menu1"></i>
+                                <span class="text">Menuplan W50</span>
+                                <span class="link">pdf</span>
+                            </a>
+                        </li>
+                    
+                        <li>
+                            <a href="/uploads/tx_netvsvgmenu_mbs5/20224100/2019W51-de_20224100.pdf" target="_blank">
+                                <i class="ico ico-menu2"></i>
+                                <span class="text">Menuplan W51</span>
+                                <span class="link">pdf</span>
+                            </a>
+                        </li>
+                    
+                    <li>
+                        <a href="#" class="trigger-newsletter">
+                            <i class="ico ico-menu-nl"></i>
+                            <span class="text">Menu Newsletter</span>
+                            <span class="link">Anmelden</span>
+                        </a>
+                    </li>
+                    
+                        <li>
+                            
+                                <a id="menu-plan-cal1" rel="nofollow" href="/de/menuplan/invite-friends/ics/1576198800/">
+                                    <i class="ico ico-menu-ics"></i>
+                                    <span class="text">Essen mit Freunden</span>
+                                    <span class="link">Einladen</span>
+                                </a>
+                            
+                                <a id="menu-plan-cal2" rel="nofollow" href="/de/menuplan/invite-friends/ics/1576458000/">
+                                    <i class="ico ico-menu-ics"></i>
+                                    <span class="text">Essen mit Freunden</span>
+                                    <span class="link">Einladen</span>
+                                </a>
+                            
+                                <a id="menu-plan-cal3" rel="nofollow" href="/de/menuplan/invite-friends/ics/1576544400/">
+                                    <i class="ico ico-menu-ics"></i>
+                                    <span class="text">Essen mit Freunden</span>
+                                    <span class="link">Einladen</span>
+                                </a>
+                            
+                                <a id="menu-plan-cal4" rel="nofollow" href="/de/menuplan/invite-friends/ics/1576630800/">
+                                    <i class="ico ico-menu-ics"></i>
+                                    <span class="text">Essen mit Freunden</span>
+                                    <span class="link">Einladen</span>
+                                </a>
+                            
+                                <a id="menu-plan-cal5" rel="nofollow" href="/de/menuplan/invite-friends/ics/1576717200/">
+                                    <i class="ico ico-menu-ics"></i>
+                                    <span class="text">Essen mit Freunden</span>
+                                    <span class="link">Einladen</span>
+                                </a>
+                            
+                        </li>
+                    
+                </ul>
+            </div>
+        </div>
+    </div>
+    
+    <div class="l-constrained l-content">
+        
+    </div>
+    
+    
+    
+    
+    
+    
+            <div id="newsletter-overlay">
+                <a href="#" class="newsletter-close" data-ajax-url="/de/menuplan/?type=66890"><i></i></a>
+        
+                <div class="newsletter-container">
+                    
+                            
+        <style>
+          .newsletter-container {
+            min-width:100%;
+          }
+          #nlSubscribeFrame {
+            width: 1px;
+            min-width: 100%;
+            border: 0;
+          }
+        </style>
+        <iframe src="https://menu-newsletter.sv-group.ch/pl/d1c/9ac7/1367/subscribe/de?id=20224100" id="nlSubscribeFrame" scrolling="no" style="overflow: hidden; height: 558px;"></iframe>
+        <!-- this plugin registered iframe-resizer for RequireJS -->
+        <!-- this plugin registered iframeresize for RequireJS -->
+    
+                        
+                </div>
+    
+            </div>
+        
+    
+    
+    
+    
+    
+    </div></div><div id="socialmedia"><div class="label">
+                    Weiterempfehlen
+                </div><div class="shariff" data-lang="de" data-services="[&quot;facebook&quot;, &quot;twitter&quot;]"><ul class="theme-color orientation-horizontal col-2"><li class="shariff-button facebook"><a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fbkw-bern.sv-restaurant.ch%2Fde%2Fmenuplan%2F" data-rel="popup" title="Bei Facebook teilen" role="button" aria-label="Bei Facebook teilen"><span class="fa fa-facebook"></span><span class="share_text">teilen</span></a></li><li class="shariff-button twitter"><a href="https://twitter.com/intent/tweet?text=Menuplan%20-%20BKW%20Atrium&amp;url=https%3A%2F%2Fbkw-bern.sv-restaurant.ch%2Fde%2Fmenuplan%2F" data-rel="popup" title="Bei Twitter teilen" role="button" aria-label="Bei Twitter teilen"><span class="fa fa-twitter"></span><span class="share_text">tweet</span></a></li></ul></div></div></main><footer id="l-footer"><div class="l-constrained l-full"><div id="footerbar"><div class="l-constrained l-wide"><div class="footer-navigation-wrap"><span class="footer-title">
+                            BKW Atrium
+                        </span><div class="footer-navigation"><nav class="footer-mainnav"><ul class="no-bullets"><li><a href="/de/menuplan/" target="_self" class="act">Menuplan</a></li><li><a href="/de/catering/" target="_self">Catering</a></li><li><a href="/de/frisch-gesund/" target="_self">Frisch &amp; Gesund</a></li><li><a href="/de/ueber-uns/" target="_self">Über uns</a></li></ul></nav><nav class="footer-metanav"><ul class="no-bullets"><li><a href="/de/feedback/" target="_self">Feedback</a></li><li><a href="/de/kontakt/" target="_self">Kontakt</a></li><li><a href="/de/disclaimer/" target="_self">Disclaimer</a></li><li><a href="/de/datenschutzerklaerung/" target="_self">Datenschutzerklärung</a></li></ul></nav></div></div><div class="footer-opening-hours"><span class="footer-title">
+                                Öffnungszeiten
+                            </span><div class="opening-hours"><p><strong>Montag bis Freitag </strong><br>
+            08.30 - 15.30 Uhr
+        </p><p><strong>Servicezeiten</strong><br>
+            11.30 - 13.30 Uhr
+        </p></div></div><div class="footer-logo"><a href="/de/menuplan/"><img src="/typo3conf/ext/netv_svm_template/Resources/Public/media/images/logos/default/logo.svg" alt="logo"></a></div></div></div><div id="footer-meta"><div class="l-constrained l-wide"><div class="copyright">
+                ©&nbsp;<span itemprop="copyrightYear">2019</span>&nbsp;<span itemprop="legalName">BKW Atrium</span></div></div></div></div></footer></div></div>
+    <!-- RequireJS module "jquery.googleanalytics" inserted by typoscript --><script>var gak = 'UA-1431446-17';window.GoogleAnalyticsObject = "__ga__";
+                    window.__ga__ = {
+                        q: [['create', gak , {'cookieDomain': 'none'}],['set', 'forceSSL', true],['set', 'anonymizeIp', true],['set', 'language', 'de'],['send','pageview']],
+                        l: Date.now()
+                    };</script>
+    
+    <script src="/typo3temp/compressor/merged-bbf5a5d7e3ce4120774f1425cca4db31-790f4f443c51efd30c2652947c82f427.js.gzip?1575290612" type="text/javascript"></script>
+    
+    
+    <!-- pageid=15628-->
+    
+    
+    </body></html>

--- a/__test__/weHaveMenuDataForToday.spec.js
+++ b/__test__/weHaveMenuDataForToday.spec.js
@@ -1,58 +1,25 @@
 const fn = require('../helpers/weHaveMenuDataForToday');
 
-const fixture = {
-  "date": "04.07.19",
-  "meals": {
-    "Brasserie": {
-      "title": "Ceasar Salat mit Speckwürfeli",
-      "description": "(Schweiz) garniert mit Chicken Nuggets (Schweiz) und Croutons",
-      "prices": [
-        "CHF 9,50",
-        "CHF 13,50"
-      ]
-    },
-    "Grün und natürlich": {
-      "title": "Griechische Gemüsepfanne",
-      "description": "mit Feta, Ofenkartoffel mit Tzatzikisauce und Rotkabissalat",
-      "prices": [
-        "CHF 9,50",
-        "CHF 13,50"
-      ]
-    },
-    "Feuer und Flamme": {
-      "title": "Grillierte Jacobsmuscheln (USA)",
-      "description": "nach Grenobler Art mit warmem Antipastigemüse und Pommes Frites",
-      "prices": [
-        "CHF 22,00",
-        "CHF 26,00"
-      ]
-    },
-    "Tagessuppe": {
-      "title": "Fischsuppe a la Bouillabaisse",
-      "description": null,
-      "prices": [
-        "CHF 1,40",
-        "CHF 1,70"
-      ]
-    },
-    "Buddha Bowl": {
-      "title": "Fresh California Bowl",
-      "description": null,
-      "prices": [
-        "CHF 12,50",
-        "CHF 16,50"
-      ]
-    }
-  }
-};
+describe('weHaveMenuDataForToday', () => {
+	test('should return false for days without menu items', () => {
+		const fixture = {
+			date: '1234',
+			meals: {},
+		};
 
-  test('weHaveMenuDataForToday returns false on a weekend', () => {
-    const sat = '06.07.19';
-    const sun = '07.07.19';
-    expect(fn(fixture, sat)).toBe(false);
-    expect(fn(fixture, sun)).toBe(false);
-  });
+		expect(fn(fixture)).toBe(false);
+	});
 
-  test('weHaveMenuDataForToday returns true for valid days', () => {
-    expect(fn(fixture, '04.07.19')).toBe(true);
-  });
+	test('should return false for days without a valid date', () => {
+		const fixture = {
+			date: '',
+			meals: {},
+		};
+
+		expect(fn(fixture)).toBe(false);
+	});
+
+	test('weHaveMenuDataForToday returns true for valid days', () => {
+		expect(fn({ date: '12-34-56', meals: { foo: {} } })).toBe(true);
+	});
+});

--- a/__test__/weHaveMenuDataForToday.spec.js
+++ b/__test__/weHaveMenuDataForToday.spec.js
@@ -1,25 +1,68 @@
 const fn = require('../helpers/weHaveMenuDataForToday');
 
+const FRIDAY = '13-12-2019';
+const SATURDAY = '14-12-2019';
+
 describe('weHaveMenuDataForToday', () => {
-	test('should return false for days without menu items', () => {
-		const fixture = {
-			date: '1234',
-			meals: {},
-		};
-
-		expect(fn(fixture)).toBe(false);
-	});
-
-	test('should return false for days without a valid date', () => {
+	test('returns false for days without meal items', () => {
 		const fixture = {
 			date: '',
 			meals: {},
 		};
 
-		expect(fn(fixture)).toBe(false);
+		expect(fn(fixture, FRIDAY)).toBe(false);
 	});
 
-	test('weHaveMenuDataForToday returns true for valid days', () => {
-		expect(fn({ date: '12-34-56', meals: { foo: {} } })).toBe(true);
+	test('returns false for 0-length date strings', () => {
+		const fixture = {
+			date: '',
+			meals: {},
+		};
+
+		expect(fn(fixture, FRIDAY)).toBe(false);
+	});
+
+	test('returns true for valid days in the XX-XX-XXXX format', () => {
+		const fixture = {
+			date: FRIDAY,
+			meals: { 
+				foo: {} 
+			}
+		};
+
+		expect(fn(fixture, FRIDAY)).toBe(true);
+	});	
+	
+	test('returns false for invalid days in the XX-XX-XXXX format', () => {
+		const fixture = {
+			date: FRIDAY,
+			meals: { 
+				foo: {} 
+			}
+		};
+
+		expect(fn(fixture, SATURDAY)).toBe(false);
+	});	
+	
+	test('returns true for valid days in XX.XX. format', () => {
+		const fixture = {
+			date: '13.12.',
+			meals: { 
+				foo: {} 
+			}
+		};
+
+		expect(fn(fixture, '13.12.')).toBe(true);
+	});	
+	
+	test('returns false for invalid days in the XX.XX. format', () => {
+		const fixture = {
+			date: '13.12.',
+			meals: { 
+				foo: {} 
+			}
+		};
+
+		expect(fn(fixture, '14.12.')).toBe(false);
 	});
 });

--- a/__test__/weHaveMenuDataForToday.spec.js
+++ b/__test__/weHaveMenuDataForToday.spec.js
@@ -25,42 +25,42 @@ describe('weHaveMenuDataForToday', () => {
 	test('returns true for valid days in the XX-XX-XXXX format', () => {
 		const fixture = {
 			date: FRIDAY,
-			meals: { 
-				foo: {} 
-			}
+			meals: {
+				foo: {},
+			},
 		};
 
 		expect(fn(fixture, FRIDAY)).toBe(true);
-	});	
-	
+	});
+
 	test('returns false for invalid days in the XX-XX-XXXX format', () => {
 		const fixture = {
 			date: FRIDAY,
-			meals: { 
-				foo: {} 
-			}
+			meals: {
+				foo: {},
+			},
 		};
 
 		expect(fn(fixture, SATURDAY)).toBe(false);
-	});	
-	
+	});
+
 	test('returns true for valid days in XX.XX. format', () => {
 		const fixture = {
 			date: '13.12.',
-			meals: { 
-				foo: {} 
-			}
+			meals: {
+				foo: {},
+			},
 		};
 
 		expect(fn(fixture, '13.12.')).toBe(true);
-	});	
-	
+	});
+
 	test('returns false for invalid days in the XX.XX. format', () => {
 		const fixture = {
 			date: '13.12.',
-			meals: { 
-				foo: {} 
-			}
+			meals: {
+				foo: {},
+			},
 		};
 
 		expect(fn(fixture, '14.12.')).toBe(false);

--- a/__test__/werdino.spec.js
+++ b/__test__/werdino.spec.js
@@ -1,5 +1,7 @@
 const fn = require('../helpers/werdino.js');
 
+jest.mock('axios');
+
 test('exports a promise with menu data', () => {
   expect.assertions(2);
   return fn().then(data => {

--- a/__test__/werdino.spec.js
+++ b/__test__/werdino.spec.js
@@ -18,8 +18,6 @@ test('exports a promise with menu data', () => {
 test('menu data', () => {
   expect.assertions(9);
   return fn().then(data => {
-    console.log(JSON.stringify(data, null, 2));
-
     // Brasserie
     const bmeal = data.meals.Brasserie;
 

--- a/handler.js
+++ b/handler.js
@@ -4,61 +4,71 @@ const noDataTodayMessage = require('./helpers/noDataTodayMessage');
 const devConfig = require('./config/config.dev.json');
 const getMenuData = require('.');
 
-const httpsArrayOnly = array => array.filter(a => a && typeof a === 'string' && a.includes('https'));
+/**
+ * Get the suppled enviornment variable, or provide a development default
+ * @param {String} envVarName
+ * @returns {Array}
+ */
+const getWebhookAddresses = envVarName => {
+	const env = process.env[envVarName];
 
-const WERDINO_WEBHOOK_ADDRESSES = process.env.WERDINO_WEBHOOK_ADDRESSES || devConfig.WERDINO_WEBHOOK_ADDRESSES;
-const BUBENBERG_WEBHOOK_ADDRESSES = process.env.BUBENBERG_WEBHOOK_ADDRESSES || devConfig.BUBENBERG_WEBHOOK_ADDRESSES;
-const BERN_ZENTWEG_WEBHOOK_ADDRESSES = process.env.BERN_ZENTWEG_WEBHOOK_ADDRESSES || devConfig.BERN_ZENTWEG_WEBHOOK_ADDRESSES;
-const BUSSIGNY_WEBHOOK_ADDRESSES = process.env.BUSSIGNY_WEBHOOK_ADDRESSES || devConfig.BUSSIGNY_WEBHOOK_ADDRESSES;
-const LE_SCOOP_WEBHOOK_ADDRESSES = process.env.LE_SCOOP_WEBHOOK_ADDRESSES || devConfig.LE_SCOOP_WEBHOOK_ADDRESSES;
-const BKW_ATRIUM_WEBHOOK_ADDRESSES = process.env.BKW_ATRIUM_WEBHOOK_ADDRESSES || devConfig.BKW_ATRIUM_WEBHOOK_ADDRESSES;
+	if (env) {
+		return env.split(',');
+	}
+
+	if (devConfig[envVarName]) {
+		return devConfig[envVarName].split(',');
+	}
+
+	throw new Error(`No enviornment variable found for ${envVarName}`);
+};
 
 const ENVIORNMENT_DATA = {
 	WERDINO: {
 		NAME: 'Werdino',
 		URL: 'https://clients.eurest.ch/de/tamediazuerich/menu',
-		WEBHOOKS: httpsArrayOnly(WERDINO_WEBHOOK_ADDRESSES.split(',')),
-		SOURCE_LANGUAGE: 'de'
+		WEBHOOKS: getWebhookAddresses('WERDINO_WEBHOOK_ADDRESSES'),
+		SOURCE_LANGUAGE: 'de',
 	},
 	BUBENBERG: {
 		NAME: 'Bubenberg',
 		URL: 'https://clients.eurest.ch/dzz/de/Bubenberg',
-		WEBHOOKS: httpsArrayOnly(BUBENBERG_WEBHOOK_ADDRESSES.split(',')),
-		SOURCE_LANGUAGE: 'de'
+		WEBHOOKS: getWebhookAddresses('BUBENBERG_WEBHOOK_ADDRESSES'),
+		SOURCE_LANGUAGE: 'de',
 	},
 	BERN_ZENTWEG: {
 		NAME: 'Bern Zentweg',
 		URL: 'https://www.eurest.ch/dzb',
-		WEBHOOKS: httpsArrayOnly(BERN_ZENTWEG_WEBHOOK_ADDRESSES.split(',')),
-		SOURCE_LANGUAGE: 'de'
+		WEBHOOKS: getWebhookAddresses('BERN_ZENTWEG_WEBHOOK_ADDRESSES'),
+		SOURCE_LANGUAGE: 'de',
 	},
 	BUSSIGNY: {
 		NAME: 'Bussigny',
 		URL: 'https://www.eurest.ch/cil',
-		WEBHOOKS: httpsArrayOnly(BUSSIGNY_WEBHOOK_ADDRESSES.split(',')),
-		SOURCE_LANGUAGE: 'fr'
+		WEBHOOKS: getWebhookAddresses('BUSSIGNY_WEBHOOK_ADDRESSES'),
+		SOURCE_LANGUAGE: 'fr',
 	},
 	LE_SCOOP: {
 		NAME: 'Le Scoop',
 		URL: 'https://www.eurest.ch/tamedia-lausanne',
-		WEBHOOKS: httpsArrayOnly(LE_SCOOP_WEBHOOK_ADDRESSES.split(',')),
-		SOURCE_LANGUAGE: 'fr'
+		WEBHOOKS: getWebhookAddresses('LE_SCOOP_WEBHOOK_ADDRESSES'),
+		SOURCE_LANGUAGE: 'fr',
 	},
 	BKW_ATRIUM: {
 		NAME: 'BKW Atrium',
 		URL: 'https://bkw-bern.sv-restaurant.ch/de/menuplan',
-		WEBHOOKS: httpsArrayOnly(BKW_ATRIUM_WEBHOOK_ADDRESSES.split(',')),
-	 SOURCE_LANGUAGE: 'de'
+		WEBHOOKS: getWebhookAddresses('BKW_ATRIUM_WEBHOOK_ADDRESSES'),
+		SOURCE_LANGUAGE: 'de',
 	},
 };
 
 function runWerdino() {
-	Object.keys(ENVIORNMENT_DATA).map(key => {
+	Object.keys(ENVIORNMENT_DATA).forEach(function(key) {
 		const slackTargetData = ENVIORNMENT_DATA[key];
 		const { URL, WEBHOOKS, NAME, SOURCE_LANGUAGE } = slackTargetData;
 
 		getMenuData(URL, SOURCE_LANGUAGE)
-			.then(async data => {
+			.then(async function(data) {
 				let blocks;
 
 				if (data.error && data.error === 'NO_MENU_DATA_TODAY') {
@@ -68,28 +78,31 @@ function runWerdino() {
 				}
 
 				await Promise.all(
-					WEBHOOKS.map(address => {
-						return new Promise((resolve, reject) => {
-							fetch(address, {
-								method: 'POST',
-								headers: {
-									'Content-Type': 'application/json',
-								},
-								body: JSON.stringify({ blocks }),
-							})
-								.then(response => {
-									console.log(response.status, response.statusText);
-									resolve();
+					WEBHOOKS.map(
+						address =>
+							new Promise((resolve, reject) => {
+								fetch(address, {
+									method: 'POST',
+									headers: {
+										'Content-Type': 'application/json',
+									},
+									body: JSON.stringify({ blocks }),
 								})
-								.catch(error => {
-									console.log('Error with Slack Webhook:', error);
-									reject();
-								});
-						});
-					})
+									.then(response => {
+										console.log(response.status, response.statusText);
+										resolve();
+									})
+									.catch(error => {
+										console.log('Error with Slack Webhook:', error);
+										reject();
+									});
+							})
+					)
 				);
 			})
-			.catch(err => console.log(`Error in getMenuData: ${err}`));
+			.catch(function(err) {
+				console.log(`Error in getMenuData: ${err}`);
+			});
 	});
 }
 

--- a/handler.js
+++ b/handler.js
@@ -8,33 +8,63 @@ const httpsArrayOnly = array => array.filter(a => a && typeof a === 'string' && 
 
 const WERDINO_WEBHOOK_ADDRESSES = process.env.WERDINO_WEBHOOK_ADDRESSES || devConfig.WERDINO_WEBHOOK_ADDRESSES;
 const BUBENBERG_WEBHOOK_ADDRESSES = process.env.BUBENBERG_WEBHOOK_ADDRESSES || devConfig.BUBENBERG_WEBHOOK_ADDRESSES;
+const BERN_ZENTWEG_WEBHOOK_ADDRESSES = process.env.BERN_ZENTWEG_WEBHOOK_ADDRESSES || devConfig.BERN_ZENTWEG_WEBHOOK_ADDRESSES;
+const BUSSIGNY_WEBHOOK_ADDRESSES = process.env.BUSSIGNY_WEBHOOK_ADDRESSES || devConfig.BUSSIGNY_WEBHOOK_ADDRESSES;
+const LE_SCOOP_WEBHOOK_ADDRESSES = process.env.LE_SCOOP_WEBHOOK_ADDRESSES || devConfig.LE_SCOOP_WEBHOOK_ADDRESSES;
+const BKW_ATRIUM_WEBHOOK_ADDRESSES = process.env.BKW_ATRIUM_WEBHOOK_ADDRESSES || devConfig.BKW_ATRIUM_WEBHOOK_ADDRESSES;
 
 const ENVIORNMENT_DATA = {
 	WERDINO: {
 		NAME: 'Werdino',
 		URL: 'https://clients.eurest.ch/de/tamediazuerich/menu',
 		WEBHOOKS: httpsArrayOnly(WERDINO_WEBHOOK_ADDRESSES.split(',')),
+		SOURCE_LANGUAGE: 'de'
 	},
 	BUBENBERG: {
 		NAME: 'Bubenberg',
 		URL: 'https://clients.eurest.ch/dzz/de/Bubenberg',
 		WEBHOOKS: httpsArrayOnly(BUBENBERG_WEBHOOK_ADDRESSES.split(',')),
+		SOURCE_LANGUAGE: 'de'
+	},
+	BERN_ZENTWEG: {
+		NAME: 'Bern Zentweg',
+		URL: 'https://www.eurest.ch/dzb',
+		WEBHOOKS: httpsArrayOnly(BERN_ZENTWEG_WEBHOOK_ADDRESSES.split(',')),
+		SOURCE_LANGUAGE: 'de'
+	},
+	BUSSIGNY: {
+		NAME: 'Bussigny',
+		URL: 'https://www.eurest.ch/cil',
+		WEBHOOKS: httpsArrayOnly(BUSSIGNY_WEBHOOK_ADDRESSES.split(',')),
+		SOURCE_LANGUAGE: 'fr'
+	},
+	LE_SCOOP: {
+		NAME: 'Le Scoop',
+		URL: 'https://www.eurest.ch/tamedia-lausanne',
+		WEBHOOKS: httpsArrayOnly(LE_SCOOP_WEBHOOK_ADDRESSES.split(',')),
+		SOURCE_LANGUAGE: 'fr'
+	},
+	BKW_ATRIUM: {
+		NAME: 'BKW Atrium',
+		URL: 'https://bkw-bern.sv-restaurant.ch/de/menuplan',
+		WEBHOOKS: httpsArrayOnly(BKW_ATRIUM_WEBHOOK_ADDRESSES.split(',')),
+	 SOURCE_LANGUAGE: 'de'
 	},
 };
 
 function runWerdino() {
 	Object.keys(ENVIORNMENT_DATA).map(key => {
 		const slackTargetData = ENVIORNMENT_DATA[key];
-		const { URL, WEBHOOKS, NAME } = slackTargetData;
+		const { URL, WEBHOOKS, NAME, SOURCE_LANGUAGE } = slackTargetData;
 
-		getMenuData(URL)
+		getMenuData(URL, SOURCE_LANGUAGE)
 			.then(async data => {
 				let blocks;
 
 				if (data.error && data.error === 'NO_MENU_DATA_TODAY') {
 					blocks = noDataTodayMessage(URL, NAME);
 				} else {
-					blocks = messageBuilder(data, URL, NAME);
+					blocks = messageBuilder(data, URL, NAME, SOURCE_LANGUAGE);
 				}
 
 				await Promise.all(

--- a/handler.js
+++ b/handler.js
@@ -1,7 +1,7 @@
 const fetch = require('fetch-everywhere');
 const messageBuilder = require('./helpers/messageBuilder');
 const noDataTodayMessage = require('./helpers/noDataTodayMessage');
-const devConfig = require('./config/config.dev.json');
+const devConfig = require('./config/config.dev.json'); // eslint-disable-line import/no-unresolved
 const getMenuData = require('.');
 
 /**

--- a/handler.js
+++ b/handler.js
@@ -62,7 +62,7 @@ const ENVIORNMENT_DATA = {
 	},
 };
 
-function runWerdino() {
+function run() {
 	Object.keys(ENVIORNMENT_DATA).forEach(function(key) {
 		const slackTargetData = ENVIORNMENT_DATA[key];
 		const { URL, WEBHOOKS, NAME, SOURCE_LANGUAGE } = slackTargetData;
@@ -106,4 +106,4 @@ function runWerdino() {
 	});
 }
 
-module.exports.runWerdino = runWerdino;
+module.exports.run = run;

--- a/helpers/bkw-atrium.js
+++ b/helpers/bkw-atrium.js
@@ -17,7 +17,8 @@ const getMenu = $ => {
     const $menuSection = $(menuSection);
 
     // Cheerio doesn't know anything about visible elements,
-    // so we should only grab the first four elements
+    // so we should only grab the first four elements because 
+    // that is what is visible by default on the Atrium menu page
     if (i > 3) {
         return;
     }

--- a/helpers/bkw-atrium.js
+++ b/helpers/bkw-atrium.js
@@ -1,0 +1,72 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+const condense = require('condense-whitespace');
+
+/**
+ * Get BKW Atrium daily menu
+ */
+const getMenu = $ => {
+  const day = {
+    date: $('label[for="mp-tab1"]').find('span.date')
+      .text()
+      .trim(),
+    meals: {},
+  };
+
+  $('.menu-item').each((i, menuSection) => {
+    const $menuSection = $(menuSection);
+
+    // Cheerio doesn't know anything about visible elements,
+    // so we should only grab the first four elements
+    if (i > 3) {
+        return;
+    }
+
+    const title = condense($menuSection
+      .find('.menu-title')
+      .text()
+      .trim());
+
+    if (!day.meals[title]) {
+        day.meals[title] = {
+            title: title,
+        };
+    }
+      
+   day.meals[title].provenance = condense($menuSection
+      .find('.menu-provenance')
+      .text()
+      .trim());
+
+    day.meals[title].description = $menuSection
+        .find('.menu-description')
+        .text()
+        .replace(/<br\s?\/>/gm, '')
+        .trim()
+        .replace(/\s+/gm, ' ');
+
+    day.meals[title].prices = $menuSection
+      .find('.menu-prices span.val')
+      .map((i, el) =>
+      $(el)
+        .text()
+        .trim() + ' CHF'
+    )
+    .get();
+      
+    day.meals[title].vegetarian = $menuSection
+      .find('.label-vegetarian').length > 0;
+  });
+
+  return day;
+};
+
+/**
+ * Export promise
+ */
+module.exports = url =>
+  axios.get(url).then(res => {
+    const { data } = res;
+
+    return getMenu(cheerio.load(data));
+  });

--- a/helpers/bkw-atrium.js
+++ b/helpers/bkw-atrium.js
@@ -6,68 +6,73 @@ const condense = require('condense-whitespace');
  * Get BKW Atrium daily menu
  */
 const getMenu = $ => {
-  const day = {
-    date: $('label[for="mp-tab1"]').find('span.date')
-      .text()
-      .trim(),
-    meals: {},
-  };
+	const day = {
+		date: $('label[for="mp-tab1"]')
+			.find('span.date')
+			.text()
+			.trim(),
+		meals: {},
+	};
 
-  $('.menu-item').each((i, menuSection) => {
-    const $menuSection = $(menuSection);
+	$('.menu-item').each((i, menuSection) => {
+		const $menuSection = $(menuSection);
 
-    // Cheerio doesn't know anything about visible elements,
-    // so we should only grab the first four elements because 
-    // that is what is visible by default on the Atrium menu page
-    if (i > 3) {
-        return;
-    }
+		// Cheerio doesn't know anything about visible elements,
+		// so we should only grab the first four elements because
+		// that is what is visible by default on the Atrium menu page
+		if (i > 3) {
+			return;
+		}
 
-    const title = condense($menuSection
-      .find('.menu-title')
-      .text()
-      .trim());
+		const title = condense(
+			$menuSection
+				.find('.menu-title')
+				.text()
+				.trim()
+		);
 
-    if (!day.meals[title]) {
-        day.meals[title] = {
-            title: title,
-        };
-    }
-      
-   day.meals[title].provenance = condense($menuSection
-      .find('.menu-provenance')
-      .text()
-      .trim());
+		if (!day.meals[title]) {
+			day.meals[title] = {
+				title,
+			};
+		}
 
-    day.meals[title].description = $menuSection
-        .find('.menu-description')
-        .text()
-        .replace(/<br\s?\/>/gm, '')
-        .trim()
-        .replace(/\s+/gm, ' ');
+		day.meals[title].provenance = condense(
+			$menuSection
+				.find('.menu-provenance')
+				.text()
+				.trim()
+		);
 
-    day.meals[title].prices = $menuSection
-      .find('.menu-prices span.val')
-      .map((i, el) =>
-      $(el)
-        .text()
-        .trim() + ' CHF'
-    )
-    .get();
-      
-    day.meals[title].vegetarian = $menuSection
-      .find('.label-vegetarian').length > 0;
-  });
+		day.meals[title].description = $menuSection
+			.find('.menu-description')
+			.text()
+			.replace(/<br\s?\/>/gm, '')
+			.trim()
+			.replace(/\s+/gm, ' ');
 
-  return day;
+		day.meals[title].prices = $menuSection
+			.find('.menu-prices span.val')
+			.map(
+				(index, el) =>
+					`${$(el)
+						.text()
+						.trim()} CHF`
+			)
+			.get();
+
+		day.meals[title].vegetarian = $menuSection.find('.label-vegetarian').length > 0;
+	});
+
+	return day;
 };
 
 /**
  * Export promise
  */
 module.exports = url =>
-  axios.get(url).then(res => {
-    const { data } = res;
+	axios.get(url).then(res => {
+		const { data } = res;
 
-    return getMenu(cheerio.load(data));
-  });
+		return getMenu(cheerio.load(data));
+	});

--- a/helpers/eurest.js
+++ b/helpers/eurest.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const cheerio = require('cheerio');
 
 /**
- * Get Werdino daily menu
+ * Get the daily menu details from a Eurest page
  */
 const getMenu = $ => {
   const day = {

--- a/helpers/eurest.js
+++ b/helpers/eurest.js
@@ -6,7 +6,8 @@ const cheerio = require('cheerio');
  */
 const getMenu = $ => {
   const day = {
-    date: $('.date').first()
+    date: $('.date')
+      .first()
       .text()
       .trim(),
     meals: {},
@@ -30,19 +31,18 @@ const getMenu = $ => {
       .trim();
 
     day.meals[category].description =
-      $menuSection
-        .find('.wide p')
-        .text()
-        .trim() || null;
+			$menuSection
+      .find('.wide p')
+      .text()
+				.trim() || null;
 
     day.meals[category].prices = $menuSection
       .find('.price-wrapper p')
-      .map((i, el) =>
-        $(el)
-          .text()
-          .trim()
-          .replace('Extern', 'CHF')
-      )
+      .map((index, el) =>
+				$(el)
+        .text()
+        .trim()
+        .replace('Extern', 'CHF'))
       .get();
   });
 
@@ -53,8 +53,8 @@ const getMenu = $ => {
  * Export promise
  */
 module.exports = url =>
-  axios.get(url).then(res => {
-    const { data } = res;
+	axios.get(url).then(res => {
+  const { data } = res;
 
-    return getMenu(cheerio.load(data));
-  });
+  return getMenu(cheerio.load(data));
+});

--- a/helpers/getDayKey.js
+++ b/helpers/getDayKey.js
@@ -4,11 +4,11 @@ const zp = require('simple-zeropad');
  * Returns a string in the form of YYYY-MM-DD
  */
 function getDayKey() {
-    const today = new Date()
-    const year = today.getFullYear() - 2000;
-    const month = zp(today.getMonth() + 1);
-    const day = zp(today.getDate())
-    return `${day}.${month}.${year}`
+	const today = new Date();
+  const year = today.getFullYear() - 2000;
+  const month = zp(today.getMonth() + 1);
+	const day = zp(today.getDate());
+	return `${day}.${month}.${year}`;
 }
 
 module.exports = getDayKey;

--- a/helpers/getTodaysDate.js
+++ b/helpers/getTodaysDate.js
@@ -2,16 +2,16 @@
  * Get today's date in a human-readable format like March 29, 2019
  */
 const getTodaysDate = () => {
-    var d = new Date()
-  
-    var options = {
-      weekday: 'long',
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric'
-    }
-  
-    return d.toLocaleDateString('en-US', options)
-  }
+	const d = new Date();
 
-  module.exports = getTodaysDate;
+  const options = {
+		weekday: 'long',
+		day: 'numeric',
+		month: 'long',
+		year: 'numeric',
+	};
+
+	return d.toLocaleDateString('en-US', options);
+};
+
+module.exports = getTodaysDate;

--- a/helpers/messageBuilder.js
+++ b/helpers/messageBuilder.js
@@ -1,4 +1,3 @@
-'use strict';
 const superb = require('superb');
 const getTodaysDate = require('./getTodaysDate');
 const { ISSUES_LINK } = require('../constants');
@@ -62,8 +61,7 @@ const sectionBuilder = (obj, sourceLangauge) => {
 			elements: [
 				{
 					type: 'mrkdwn',
-					text: `${obj.price}\n \n`,
-				},
+					text: `${obj.price}\n\n`},
 			],
 		},
 	];
@@ -85,7 +83,7 @@ function messageBuilder(obj, url, name, sourceLangauge) {
 			type: 'section',
 			text: {
 				type: 'mrkdwn',
-				text: `${name} menu for *${getTodaysDate()}*\n \n`,
+				text: `${name} menu for *${getTodaysDate()}*\n\n`,
 			},
 		},
 	];
@@ -99,7 +97,7 @@ function messageBuilder(obj, url, name, sourceLangauge) {
 					type: 'mrkdwn',
 					text: `${getIconForTitle(o.title)} *${o.titleEn}*`,
 				},
-			})
+			});
 		}
 		blocks = blocks.concat([...sectionBuilder(o, sourceLangauge)]);
 	});
@@ -116,13 +114,13 @@ function messageBuilder(obj, url, name, sourceLangauge) {
 	});
 
 	// Now let's add a green note
-	blocks.push({type: 'divider'});
+	blocks.push({ type: 'divider' });
 	blocks.push({
 		type: 'section',
 		text: {
 			type: 'mrkdwn',
-			text: `:earth_asia: :green_heart: *Remember*: Using ${name}'s washable dishes and cutlery is more eco-friendly.`
-		}
+			text: `:earth_asia: :green_heart: *Remember*: Using ${name}'s washable dishes and cutlery is more eco-friendly.`,
+		},
 	});
 
 	return blocks;

--- a/helpers/messageBuilder.js
+++ b/helpers/messageBuilder.js
@@ -8,7 +8,7 @@ const { ISSUES_LINK } = require('../constants');
  * @param {String} title
  */
 const getIconForTitle = title => {
-	const lowerTitle = title.toLowerCase();
+	const lowerTitle = title.toLowerCase().trim();
 	switch (lowerTitle) {
 		case 'brasserie':
 			return ':meat_on_bone:';
@@ -39,19 +39,11 @@ const getDescription = str => {
  * Build a block for Slack using the supplied language data
  * @param {Object} obj
  */
-const sectionBuilder = obj => {
+const sectionBuilder = (obj, sourceLangauge) => {
 	const section = [
-		{
-			type: 'section',
-			text: {
-				type: 'mrkdwn',
-				text: `${getIconForTitle(obj.title)} *${obj.titleEn}*`,
-			},
-		},
 		{
 			type: 'divider',
 		},
-
 		{
 			type: 'section',
 			fields: [
@@ -61,7 +53,7 @@ const sectionBuilder = obj => {
 				},
 				{
 					type: 'mrkdwn',
-					text: `\`DE\` *${obj.mealTitle}*\n${getDescription(obj.description)}`,
+					text: `\`${sourceLangauge.toUpperCase()}\` *${obj.mealTitle}*\n${getDescription(obj.description)}`,
 				},
 			],
 		},
@@ -84,8 +76,9 @@ const sectionBuilder = obj => {
  * @param {Object} obj
  * @param {String} url
  * @param {String} name
+ * @param {String} sourceLangauge
  */
-function messageBuilder(obj, url, name) {
+function messageBuilder(obj, url, name, sourceLangauge) {
 	// Blocks starts off with Header only
 	let blocks = [
 		{
@@ -99,7 +92,16 @@ function messageBuilder(obj, url, name) {
 
 	// Now add in each section with the menu information for the day
 	obj.forEach(o => {
-		blocks = blocks.concat([...sectionBuilder(o)]);
+		if (url.includes('eurest')) {
+			blocks.push({
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `${getIconForTitle(o.title)} *${o.titleEn}*`,
+				},
+			})
+		}
+		blocks = blocks.concat([...sectionBuilder(o, sourceLangauge)]);
 	});
 
 	// Now attach the footer

--- a/helpers/noDataTodayMessage.js
+++ b/helpers/noDataTodayMessage.js
@@ -1,10 +1,9 @@
-'use strict';
 const superb = require('superb');
 const getTodaysDate = require('./getTodaysDate');
 const { ISSUES_LINK } = require('../constants');
 
 function noDataTodayMessage(url, name) {
-	let blocks = [
+	const blocks = [
 		{
 			type: 'section',
 			text: {

--- a/helpers/weHaveMenuDataForToday.js
+++ b/helpers/weHaveMenuDataForToday.js
@@ -1,10 +1,39 @@
 /**
- * Validate that we have menu data for the given date key
- * @param {Object} menuData - the scraped data from the online Werdino menue
+ * Strip date strings of punctuation values.
+ *
+ * @note We might get date info in the format of XX.XX. or XX-XX-XXXX
+ * So let's remove the punctuation that would just leave us with
+ * only the integer parts of the date.
+ * @param {String} dateString
+ * @returns {String}
  */
-function weHaveMenuDataForToday(menuData) {
+function clean(dateString) {
+	if (!typeof dateString === 'string') {
+		return '';
+	}
+	return dateString.replace(/\.|-/gm, '').trim();
+}
+
+/**
+ * Validate that we have menu data for the given date key.
+ * 
+ * @param {Object} menuData - the scraped data from the website in object form
+ * @param {String} todaysDate - today's date in the form of XX-XX-XXXX
+ * @returns {Boolean}
+ */
+function weHaveMenuDataForToday(menuData, todaysDate) {
 	const { date, meals } = menuData;
-	return typeof date === 'string' && date.trim().length > 0 && meals && Object.keys(meals).length > 0;
+
+	const convertedDate = clean(date);
+	const convertedTodaysDate = clean(todaysDate);
+
+	return (
+		convertedDate.length > 0 &&
+		convertedTodaysDate.length > 0 &&
+		convertedTodaysDate.search(convertedDate) === 0 &&
+		meals &&
+		Object.keys(meals).length > 0
+	);
 }
 
 module.exports = weHaveMenuDataForToday;

--- a/helpers/weHaveMenuDataForToday.js
+++ b/helpers/weHaveMenuDataForToday.js
@@ -8,7 +8,7 @@
  * @returns {String}
  */
 function clean(dateString) {
-	if (!typeof dateString === 'string') {
+	if (typeof dateString !== 'string') {
 		return '';
 	}
 	return dateString.replace(/\.|-/gm, '').trim();
@@ -16,7 +16,7 @@ function clean(dateString) {
 
 /**
  * Validate that we have menu data for the given date key.
- * 
+ *
  * @param {Object} menuData - the scraped data from the website in object form
  * @param {String} todaysDate - today's date in the form of XX-XX-XXXX
  * @returns {Boolean}

--- a/helpers/weHaveMenuDataForToday.js
+++ b/helpers/weHaveMenuDataForToday.js
@@ -1,10 +1,10 @@
 /**
  * Validate that we have menu data for the given date key
  * @param {Object} menuData - the scraped data from the online Werdino menue
- * @param {*} todaysItemKey - today's date key in the form of '2019-03-30'
  */
-function weHaveMenuDataForToday(menuData, todaysItemKey) {
-    return menuData.date === todaysItemKey && Object.keys(menuData.meals).length > 0;
+function weHaveMenuDataForToday(menuData) {
+	const { date, meals } = menuData;
+	return typeof date === 'string' && date.trim().length > 0 && meals && Object.keys(meals).length > 0;
 }
 
-module.exports = weHaveMenuDataForToday; 
+module.exports = weHaveMenuDataForToday;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const condense = require('condense-whitespace');
 const getDayKey = require('./helpers/getDayKey');
 const weHaveMenuDataForToday = require('./helpers/weHaveMenuDataForToday');
 const werdino = require('./helpers/werdino');
+const atrium = require('./helpers/bkw-atrium');
 const todaysItemKey = getDayKey();
 
 // Use these special tokens to add some semantics to the data we scrape from 
@@ -58,15 +59,18 @@ function objectify(text) {
 /**
  * Get an object containing the scraped menu data from the supplied url
  * @param {String} url
+ * @param {String} sourceLanguage
  * @returns {Object}
  */
-const getMenuData = url => {
+const getMenuData = (url, sourceLanguage) => {
 	// Here we will store the German text with special delimeters.
 	let german = '';
 
 	return new Promise((resolve, reject) => {
-		werdino(url).then(data => {
-			if (!weHaveMenuDataForToday(data, todaysItemKey)) {
+		const scapePage = url.includes('eurest') ? werdino : atrium;
+
+		scapePage(url).then(data => {
+			if (!weHaveMenuDataForToday(data)) {
 				resolve({ error: 'NO_MENU_DATA_TODAY', todaysItemKey });
 			} else {
 				Object.keys(data.meals).forEach(category => {
@@ -88,7 +92,7 @@ const getMenuData = url => {
 				});
 
 				const translationRequest = translate.translateText({
-					SourceLanguageCode: 'de',
+					SourceLanguageCode: sourceLanguage,
 					TargetLanguageCode: 'en',
 					Text: german,
 				});

--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ const weHaveMenuDataForToday = require('./helpers/weHaveMenuDataForToday');
 const eurest = require('./helpers/eurest');
 const atrium = require('./helpers/bkw-atrium');
 
-// Use these special tokens to add some semantics to the data we scrape from 
+// Use these special tokens to add some semantics to the data we scrape from
 // the webpages. This will allow us to send a single string to the translate API
 // (which saves time and cost) and give us a way to parse / grep the values out of
 // the string later on (like when we want to build a data object from the scraped
-// and translated values). 
+// and translated values).
 const TITLE_TOKEN = '[T_] ';
 const PRICE_TOKEN = '[M_P] ';
 const DESCRIPTION_TOKEN = '[M_D] ';
@@ -18,7 +18,7 @@ const SEPERATOR = '🦄\n';
 
 // Cost per character via AWS Translate
 // https://aws.amazon.com/translate/pricing/
-const COST_PER_CHARACTER = 0.000015;
+const COST_PER_CHAR = 0.000015;
 
 // Creates a client
 const translate = new AWS.Translate({ apiVersion: '2017-07-01' });
@@ -98,40 +98,44 @@ const getMenuData = (url, sourceLanguage) => {
 					Text: originalText,
 				});
 
-				translationRequest
-					.on('success', function(response) {
-						const originalTextObject = objectify(originalText);
+				translationRequest.on('success', function(response) {
+					const originalTextObject = objectify(originalText);
 
-						if (!response || !response.data || !response.data.TranslatedText) {
-							reject(new Error('Unknown translation error occured'));
-							return;
+					if (!response || !response.data || !response.data.TranslatedText) {
+						reject(new Error('Unknown translation error occured'));
+						return;
+					}
+
+					const englishObject = objectify(response.data.TranslatedText);
+
+					// Merge the english translations with the original language
+					// to make the block building easier
+					englishObject.forEach((obj, index) => {
+						if (obj.title) {
+							originalTextObject[index].titleEn = obj.title;
 						}
+						if (obj.mealTitle) {
+							originalTextObject[index].mealTitleEn = obj.mealTitle;
+						}
+						if (obj.description) {
+							originalTextObject[index].descriptionEn = obj.description;
+						}
+					});
 
-						const englishObject = objectify(response.data.TranslatedText);
+					const textLength = originalText.length;
+					const cost = `${textLength * COST_PER_CHAR} USD`;
+					console.log(`Cost: ${textLength} chars * ${COST_PER_CHAR} = ${cost}`);
 
-						// Merge the english translations with the original language
-						//  to make the block building easier
-						englishObject.forEach((obj, index) => {
-							if (obj.title) {
-								originalTextObject[index].titleEn = obj.title;
-							}
-							if (obj.mealTitle) {
-								originalTextObject[index].mealTitleEn = obj.mealTitle;
-							}
-							if (obj.description) {
-								originalTextObject[index].descriptionEn = obj.description;
-							}
-						});
+					resolve(originalTextObject);
+				});
 
-						console.log(`Cost: ${originalText.length} characters * ${COST_PER_CHARACTER}/per char = ${originalText.length * COST_PER_CHARACTER} USD`);
-						resolve(originalTextObject);
-					})
-					.on('error', function(error, response) {
-						console.log('Error!');
-						console.log({ error, response });
-						reject(error);
-					})
-					.send();
+				translationRequest.on('error', function(error, response) {
+					console.log('Error!');
+					console.log({ error, response });
+					reject(error);
+				});
+
+				translationRequest.send();
 			}
 		});
 	});

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const AWS = require('aws-sdk');
 const condense = require('condense-whitespace');
 const getTodaysDateKey = require('./helpers/getDayKey');
 const weHaveMenuDataForToday = require('./helpers/weHaveMenuDataForToday');
-const werdino = require('./helpers/werdino');
+const eurest = require('./helpers/eurest');
 const atrium = require('./helpers/bkw-atrium');
 
 // Use these special tokens to add some semantics to the data we scrape from 
@@ -66,7 +66,7 @@ const getMenuData = (url, sourceLanguage) => {
 	let german = '';
 
 	return new Promise((resolve, reject) => {
-		const scapePage = url.includes('eurest') ? werdino : atrium;
+		const scapePage = url.includes('eurest') ? eurest : atrium;
 
 		scapePage(url).then(data => {
 			const todaysItemKey = getTodaysDateKey();

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 const AWS = require('aws-sdk');
 const condense = require('condense-whitespace');
-const getDayKey = require('./helpers/getDayKey');
+const getTodaysDateKey = require('./helpers/getDayKey');
 const weHaveMenuDataForToday = require('./helpers/weHaveMenuDataForToday');
 const werdino = require('./helpers/werdino');
 const atrium = require('./helpers/bkw-atrium');
-const todaysItemKey = getDayKey();
 
 // Use these special tokens to add some semantics to the data we scrape from 
 // the webpages. This will allow us to send a single string to the translate API
@@ -70,7 +69,9 @@ const getMenuData = (url, sourceLanguage) => {
 		const scapePage = url.includes('eurest') ? werdino : atrium;
 
 		scapePage(url).then(data => {
-			if (!weHaveMenuDataForToday(data)) {
+			const todaysItemKey = getTodaysDateKey();
+
+			if (!weHaveMenuDataForToday(data, todaysItemKey)) {
 				resolve({ error: 'NO_MENU_DATA_TODAY', todaysItemKey });
 			} else {
 				Object.keys(data.meals).forEach(category => {

--- a/index.js
+++ b/index.js
@@ -62,8 +62,8 @@ function objectify(text) {
  * @returns {Object}
  */
 const getMenuData = (url, sourceLanguage) => {
-	// Here we will store the German text with special delimeters.
-	let german = '';
+	// Here we will store the orignal text with special delimeters.
+	let originalText = '';
 
 	return new Promise((resolve, reject) => {
 		const scapePage = url.includes('eurest') ? eurest : atrium;
@@ -77,30 +77,30 @@ const getMenuData = (url, sourceLanguage) => {
 				Object.keys(data.meals).forEach(category => {
 					const item = data.meals[category];
 
-					german += `${TITLE_TOKEN} ${condense(category)}\n`;
+					originalText += `${TITLE_TOKEN} ${condense(category)}\n`;
 
 					const mealTitle = condense(item.title);
 					const mealDescription = condense(item.description || '');
 
-					german += `${MEAL_TITLE_TOKEN} ${mealTitle}\n`;
+					originalText += `${MEAL_TITLE_TOKEN} ${mealTitle}\n`;
 
 					if (mealDescription) {
-						german += `${DESCRIPTION_TOKEN} ${mealDescription}\n`;
+						originalText += `${DESCRIPTION_TOKEN} ${mealDescription}\n`;
 					}
 
-					german += `${PRICE_TOKEN} ${item.prices.map(s => condense(s)).join(' | ')}\n`;
-					german += SEPERATOR;
+					originalText += `${PRICE_TOKEN} ${item.prices.map(s => condense(s)).join(' | ')}\n`;
+					originalText += SEPERATOR;
 				});
 
 				const translationRequest = translate.translateText({
 					SourceLanguageCode: sourceLanguage,
 					TargetLanguageCode: 'en',
-					Text: german,
+					Text: originalText,
 				});
 
 				translationRequest
 					.on('success', function(response) {
-						const germanObject = objectify(german);
+						const originalTextObject = objectify(originalText);
 
 						if (!response || !response.data || !response.data.TranslatedText) {
 							reject(new Error('Unknown translation error occured'));
@@ -109,21 +109,22 @@ const getMenuData = (url, sourceLanguage) => {
 
 						const englishObject = objectify(response.data.TranslatedText);
 
-						// Merge the english translations with the German to make the block building easier
+						// Merge the english translations with the original language
+						//  to make the block building easier
 						englishObject.forEach((obj, index) => {
 							if (obj.title) {
-								germanObject[index].titleEn = obj.title;
+								originalTextObject[index].titleEn = obj.title;
 							}
 							if (obj.mealTitle) {
-								germanObject[index].mealTitleEn = obj.mealTitle;
+								originalTextObject[index].mealTitleEn = obj.mealTitle;
 							}
 							if (obj.description) {
-								germanObject[index].descriptionEn = obj.description;
+								originalTextObject[index].descriptionEn = obj.description;
 							}
 						});
 
-						console.log(`Cost: ${german.length} characters * ${COST_PER_CHARACTER}/per char = ${german.length * COST_PER_CHARACTER} USD`);
-						resolve(germanObject);
+						console.log(`Cost: ${originalText.length} characters * ${COST_PER_CHARACTER}/per char = ${originalText.length * COST_PER_CHARACTER} USD`);
+						resolve(originalTextObject);
 					})
 					.on('error', function(error, response) {
 						console.log('Error!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,18 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -144,6 +156,25 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/runtime": {
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+			"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+			"dev": true,
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
+		"@babel/runtime-corejs3": {
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.6.tgz",
+			"integrity": "sha512-NrRUehqG0sMSCaP+0XV/vOvvjNl4BQOWq3Qys1Q2KTEm5tGMo9h0dHnIzeKerj0a7SIB8LP5kYg/T1raE3FoKQ==",
+			"dev": true,
+			"requires": {
+				"core-js-pure": "^3.0.0",
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
 		"@babel/template": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
@@ -180,6 +211,12 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -202,6 +239,14 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"@jest/console": {
@@ -213,6 +258,14 @@
 				"@jest/source-map": "^24.9.0",
 				"chalk": "^2.0.1",
 				"slash": "^2.0.0"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/core": {
@@ -249,6 +302,14 @@
 				"rimraf": "^2.5.4",
 				"slash": "^2.0.0",
 				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/environment": {
@@ -301,6 +362,14 @@
 				"slash": "^2.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^2.0.0"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/source-map": {
@@ -359,6 +428,14 @@
 				"slash": "^2.0.0",
 				"source-map": "^0.6.1",
 				"write-file-atomic": "2.4.1"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/types": {
@@ -386,9 +463,9 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
-			"integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
@@ -412,6 +489,12 @@
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
+		},
+		"@types/eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+			"dev": true
 		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
@@ -438,10 +521,22 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
+		"@types/json-schema": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+			"dev": true
+		},
 		"@types/node": {
-			"version": "12.12.16",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.16.tgz",
-			"integrity": "sha512-vRuMyoOr5yfNf8QWxXegOjeyjpWJxFePzHzmBOIzDIzo+rSqF94RW0PkS6y4T2+VjAWLXHWrfbIJY3E3aS7lUw=="
+			"version": "12.12.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.17.tgz",
+			"integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA=="
+		},
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+			"dev": true
 		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
@@ -464,6 +559,59 @@
 			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
 			"dev": true
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+			"dev": true,
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "1.13.0",
+				"eslint-scope": "^4.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				}
+			}
+		},
+		"@typescript-eslint/parser": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+			"integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+			"dev": true,
+			"requires": {
+				"@types/eslint-visitor-keys": "^1.0.0",
+				"@typescript-eslint/experimental-utils": "1.13.0",
+				"@typescript-eslint/typescript-estree": "1.13.0",
+				"eslint-visitor-keys": "^1.0.0"
+			}
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+			"dev": true,
+			"requires": {
+				"lodash.unescape": "4.0.1",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"dev": true
+				}
+			}
+		},
 		"abab": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -471,9 +619,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+			"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -493,6 +641,12 @@
 					"dev": true
 				}
 			}
+		},
+		"acorn-jsx": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "6.2.0",
@@ -519,9 +673,9 @@
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -541,6 +695,25 @@
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"aria-query": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"dev": true,
+			"requires": {
+				"ast-types-flow": "0.0.7",
+				"commander": "^2.11.0"
 			}
 		},
 		"arr-diff": {
@@ -566,6 +739,16 @@
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
+		},
+		"array-includes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+			"integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.0"
+			}
 		},
 		"array-unique": {
 			"version": "0.3.2",
@@ -594,6 +777,12 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
+		"ast-types-flow": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+			"dev": true
+		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -619,9 +808,9 @@
 			"dev": true
 		},
 		"aws-sdk": {
-			"version": "2.587.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.587.0.tgz",
-			"integrity": "sha512-MAdUE4BC+hyfFPoQc61aV/tIfApp5ifqe3segW4GJq6dMmSCZdFbDwvs5ZUkgOSJ4ks3ZrpH9eCHpt6r0dFJYQ==",
+			"version": "2.590.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.590.0.tgz",
+			"integrity": "sha512-cdH3B/IuEuds84zRvi52WEW0UXOjsyl9hEkdbS2Uo8P7pWepaKTOZ3BKIUsy/lXen0nHcRWDCHeUkBwNW1Q2bg==",
 			"requires": {
 				"buffer": "4.9.1",
 				"events": "1.1.1",
@@ -632,18 +821,6 @@
 				"url": "0.10.3",
 				"uuid": "3.3.2",
 				"xml2js": "0.4.19"
-			},
-			"dependencies": {
-				"sax": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-					"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-				},
-				"uuid": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-				}
 			}
 		},
 		"aws-sign2": {
@@ -667,6 +844,16 @@
 				"is-buffer": "^2.0.2"
 			}
 		},
+		"axobject-query": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
+			"integrity": "sha512-lF98xa/yvy6j3fBHAgQXIYl+J4eZadOSqsPojemUqClzNbBV38wWGpUbQbVEyf4eUF5yF7eHmGgGA2JiHyjeqw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.7.4",
+				"@babel/runtime-corejs3": "^7.7.4"
+			}
+		},
 		"babel-jest": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -680,6 +867,14 @@
 				"babel-preset-jest": "^24.9.0",
 				"chalk": "^2.4.2",
 				"slash": "^2.0.0"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -692,6 +887,51 @@
 				"find-up": "^3.0.0",
 				"istanbul-lib-instrument": "^3.3.0",
 				"test-exclude": "^5.2.3"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				}
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -786,6 +1026,16 @@
 			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
+			}
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
 			}
 		},
 		"boolbase": {
@@ -897,6 +1147,32 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"dev": true,
+			"requires": {
+				"callsites": "^2.0.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
+				}
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"dev": true,
+			"requires": {
+				"caller-callsite": "^2.0.0"
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -934,6 +1210,12 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
+		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.3",
@@ -977,6 +1259,21 @@
 				}
 			}
 		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
 		"cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -986,6 +1283,19 @@
 				"string-width": "^3.1.0",
 				"strip-ansi": "^5.2.0",
 				"wrap-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"co": {
@@ -1032,8 +1342,13 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"optional": true
+			"dev": true
+		},
+		"common-tags": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"dev": true
 		},
 		"component-emitter": {
 			"version": "1.3.0",
@@ -1052,6 +1367,18 @@
 			"resolved": "https://registry.npmjs.org/condense-whitespace/-/condense-whitespace-1.0.0.tgz",
 			"integrity": "sha1-g3bZjvAo5sss0kaOKM5CxcZasak="
 		},
+		"confusing-browser-globals": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
+			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+			"dev": true
+		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
+		},
 		"convert-source-map": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -1059,6 +1386,14 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"copy-descriptor": {
@@ -1067,11 +1402,63 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
+		"core-js": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+			"integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw==",
+			"dev": true
+		},
+		"core-js-pure": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+			"integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA==",
+			"dev": true
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
+		},
+		"cosmiconfig": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+			"dev": true,
+			"requires": {
+				"import-fresh": "^2.0.0",
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.13.1",
+				"parse-json": "^4.0.0"
+			},
+			"dependencies": {
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"dev": true,
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
+			}
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -1084,6 +1471,14 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"css-select": {
@@ -1117,6 +1512,12 @@
 				"cssom": "0.3.x"
 			}
 		},
+		"damerau-levenshtein": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+			"integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
+			"dev": true
+		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1148,6 +1549,14 @@
 						"webidl-conversions": "^4.0.2"
 					}
 				}
+			}
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
 			}
 		},
 		"decamelize": {
@@ -1235,6 +1644,21 @@
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
 			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
 			"dev": true
+		},
+		"dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+			"dev": true
+		},
+		"doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2"
+			}
 		},
 		"dom-serializer": {
 			"version": "0.1.1",
@@ -1324,9 +1748,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
-			"integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+			"version": "1.17.0-next.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+			"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
@@ -1337,6 +1761,7 @@
 				"is-regex": "^1.0.4",
 				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.0",
 				"string.prototype.trimleft": "^2.1.0",
 				"string.prototype.trimright": "^2.1.0"
 			}
@@ -1369,13 +1794,320 @@
 				"esutils": "^2.0.2",
 				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				}
+			}
+		},
+		"eslint": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
+			"integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.10.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^1.4.2",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.1",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^5.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.0.0",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^6.4.1",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.14",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.1",
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
+				"table": "^5.2.3",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-config-airbnb": {
+			"version": "18.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.0.1.tgz",
+			"integrity": "sha512-hLb/ccvW4grVhvd6CT83bECacc+s4Z3/AEyWQdIT2KeTsG9dR7nx1gs7Iw4tDmGKozCNHFn4yZmRm3Tgy+XxyQ==",
+			"dev": true,
+			"requires": {
+				"eslint-config-airbnb-base": "^14.0.0",
+				"object.assign": "^4.1.0",
+				"object.entries": "^1.1.0"
+			}
+		},
+		"eslint-config-airbnb-base": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
+			"integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
+			"dev": true,
+			"requires": {
+				"confusing-browser-globals": "^1.0.7",
+				"object.assign": "^4.1.0",
+				"object.entries": "^1.1.0"
+			}
+		},
+		"eslint-config-prettier": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.2.0.tgz",
+			"integrity": "sha512-VLsgK/D+S/FEsda7Um1+N8FThec6LqE3vhcMyp8mlmto97y3fGf3DX7byJexGuOb1QY0Z/zz222U5t+xSfcZDQ==",
+			"dev": true,
+			"requires": {
+				"get-stdin": "^6.0.0"
+			}
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
+			"integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"pkg-dir": "^2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-eslint-plugin": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz",
+			"integrity": "sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg==",
+			"dev": true
+		},
+		"eslint-plugin-import": {
+			"version": "2.18.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+			"integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.2",
+				"eslint-module-utils": "^2.4.0",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.0",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.11.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-jest": {
+			"version": "22.16.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.16.0.tgz",
+			"integrity": "sha512-eBtSCDhO1k7g3sULX/fuRK+upFQ7s548rrBtxDyM1fSoY7dTWp/wICjrJcDZKVsW7tsFfH22SG+ZaxG5BZodIg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^1.13.0"
+			}
+		},
+		"eslint-plugin-jsx-a11y": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+			"integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.5",
+				"aria-query": "^3.0.0",
+				"array-includes": "^3.0.3",
+				"ast-types-flow": "^0.0.7",
+				"axobject-query": "^2.0.2",
+				"damerau-levenshtein": "^1.0.4",
+				"emoji-regex": "^7.0.2",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.2.1"
+			}
+		},
+		"eslint-plugin-prettier": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+			"integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
+			"dev": true,
+			"requires": {
+				"prettier-linter-helpers": "^1.0.0"
+			}
+		},
+		"eslint-plugin-react": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz",
+			"integrity": "sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"doctrine": "^2.1.0",
+				"eslint-plugin-eslint-plugin": "^2.1.0",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.2.3",
+				"object.entries": "^1.1.0",
+				"object.fromentries": "^2.0.1",
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2",
+				"resolve": "^1.13.1"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				}
+			}
+		},
+		"eslint-scope": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+			"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			}
+		},
+		"eslint-utils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.1.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"dev": true
+		},
+		"espree": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"esprima": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.0.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.1.0"
+			}
 		},
 		"estraverse": {
 			"version": "4.3.0",
@@ -1462,12 +2194,6 @@
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
@@ -1510,6 +2236,17 @@
 						"is-plain-object": "^2.0.4"
 					}
 				}
+			}
+		},
+		"external-editor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"dev": true,
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -1589,6 +2326,12 @@
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
 		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"dev": true
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -1617,18 +2360,32 @@
 			"requires": {
 				"node-fetch": "^1.0.1",
 				"whatwg-fetch": ">=0.10.0"
-			},
-			"dependencies": {
-				"node-fetch": {
-					"version": "1.7.3",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-					"requires": {
-						"encoding": "^0.1.11",
-						"is-stream": "^1.0.1"
-					}
-				}
 			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -1654,13 +2411,30 @@
 			}
 		},
 		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^2.0.0"
 			}
+		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"dev": true,
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			}
+		},
+		"flatted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+			"dev": true
 		},
 		"follow-redirects": {
 			"version": "1.5.10",
@@ -1668,21 +2442,6 @@
 			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
 			"requires": {
 				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
 			}
 		},
 		"for-in": {
@@ -1696,6 +2455,17 @@
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -1713,14 +2483,15 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+			"integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
+				"bindings": "^1.5.0",
 				"nan": "^2.12.1",
-				"node-pre-gyp": "^0.12.0"
+				"node-pre-gyp": "*"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -1768,7 +2539,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.1.1",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1798,7 +2569,7 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "4.1.1",
+					"version": "3.2.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1825,12 +2596,12 @@
 					"optional": true
 				},
 				"fs-minipass": {
-					"version": "1.2.5",
+					"version": "1.2.7",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "^2.6.0"
 					}
 				},
 				"fs.realpath": {
@@ -1856,7 +2627,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.3",
+					"version": "7.1.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1885,7 +2656,7 @@
 					}
 				},
 				"ignore-walk": {
-					"version": "3.0.1",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1904,7 +2675,7 @@
 					}
 				},
 				"inherits": {
-					"version": "2.0.3",
+					"version": "2.0.4",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1946,7 +2717,7 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.3.5",
+					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1956,12 +2727,12 @@
 					}
 				},
 				"minizlib": {
-					"version": "1.2.1",
+					"version": "1.3.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "^2.9.0"
 					}
 				},
 				"mkdirp": {
@@ -1974,24 +2745,24 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
+					"version": "2.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.3.0",
+					"version": "2.4.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^4.1.0",
+						"debug": "^3.2.6",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.12.0",
+					"version": "0.14.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2005,7 +2776,7 @@
 						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
-						"tar": "^4"
+						"tar": "^4.4.2"
 					}
 				},
 				"nopt": {
@@ -2019,13 +2790,22 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.6",
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"npm-normalize-package-bin": "^1.0.1"
+					}
+				},
+				"npm-normalize-package-bin": {
+					"version": "1.0.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.4.1",
+					"version": "1.4.7",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2096,7 +2876,7 @@
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2137,7 +2917,7 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.3",
+					"version": "2.7.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2164,7 +2944,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.7.0",
+					"version": "5.7.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2217,18 +2997,18 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.8",
+					"version": "4.4.13",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
 						"mkdirp": "^0.5.0",
 						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
+						"yallist": "^3.0.3"
 					}
 				},
 				"util-deprecate": {
@@ -2253,7 +3033,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.3",
+					"version": "3.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2266,10 +3046,22 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-stdin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 			"dev": true
 		},
 		"get-stream": {
@@ -2308,6 +3100,15 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+			"dev": true,
+			"requires": {
+				"is-glob": "^4.0.1"
 			}
 		},
 		"globals": {
@@ -2363,6 +3164,23 @@
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
 			}
 		},
 		"has-flag": {
@@ -2441,18 +3259,6 @@
 				"entities": "^1.1.1",
 				"inherits": "^2.0.1",
 				"readable-stream": "^3.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
 			}
 		},
 		"http-signature": {
@@ -2464,6 +3270,115 @@
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
+			}
+		},
+		"husky": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-3.1.0.tgz",
+			"integrity": "sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"ci-info": "^2.0.0",
+				"cosmiconfig": "^5.2.1",
+				"execa": "^1.0.0",
+				"get-stdin": "^7.0.0",
+				"opencollective-postinstall": "^2.0.2",
+				"pkg-dir": "^4.2.0",
+				"please-upgrade-node": "^3.2.0",
+				"read-pkg": "^5.2.0",
+				"run-node": "^1.0.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"get-stdin": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+					"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					}
+				}
 			}
 		},
 		"iconv-lite": {
@@ -2479,6 +3394,22 @@
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
+		"ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true
+		},
+		"import-fresh": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+			"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			}
+		},
 		"import-local": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -2487,12 +3418,72 @@
 			"requires": {
 				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				}
 			}
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
 			"dev": true
 		},
 		"inflight": {
@@ -2509,6 +3500,27 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"inquirer": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.12",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.4.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.1.0",
+				"through": "^2.3.6"
+			}
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -2622,10 +3634,22 @@
 				}
 			}
 		},
+		"is-directory": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
+		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
 		},
 		"is-fullwidth-code-point": {
@@ -2639,6 +3663,15 @@
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -2674,6 +3707,12 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -2758,14 +3797,6 @@
 				"@babel/types": "^7.4.0",
 				"istanbul-lib-coverage": "^2.0.5",
 				"semver": "^6.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-lib-report": {
@@ -2811,6 +3842,12 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -3039,6 +4076,14 @@
 				"micromatch": "^3.1.10",
 				"slash": "^2.0.0",
 				"stack-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"jest-mock": {
@@ -3142,6 +4187,14 @@
 				"slash": "^2.0.0",
 				"strip-bom": "^3.0.0",
 				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"jest-serializer": {
@@ -3169,14 +4222,6 @@
 				"natural-compare": "^1.4.0",
 				"pretty-format": "^24.9.0",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
 			}
 		},
 		"jest-util": {
@@ -3197,6 +4242,14 @@
 				"mkdirp": "^0.5.1",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
 			}
 		},
 		"jest-validate": {
@@ -3260,6 +4313,16 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
+		"js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -3300,10 +4363,22 @@
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+					"dev": true
+				},
 				"parse5": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+					"dev": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true
 				}
 			}
@@ -3332,6 +4407,12 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3345,6 +4426,14 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"jsprim": {
@@ -3357,6 +4446,16 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
+			}
+		},
+		"jsx-ast-utils": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+			"integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"object.assign": "^4.1.0"
 			}
 		},
 		"kind-of": {
@@ -3393,33 +4492,31 @@
 				"type-check": "~0.3.2"
 			}
 		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
+		},
 		"load-json-file": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
 				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
 			}
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^3.0.0",
+				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
@@ -3428,11 +4525,81 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+			"dev": true
+		},
+		"loglevel": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
+			"integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
+			"dev": true
+		},
+		"loglevel-colored-level-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+			"integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"loglevel": "^1.4.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -3451,6 +4618,20 @@
 			"requires": {
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"makeerror": {
@@ -3519,6 +4700,12 @@
 				"mime-db": "1.42.0"
 			}
 		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3529,9 +4716,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
 		"mixin-deep": {
@@ -3562,20 +4749,17 @@
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				}
 			}
 		},
 		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
 		"nan": {
@@ -3622,6 +4806,15 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
+			}
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3645,6 +4838,14 @@
 				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-package-data": {
@@ -3657,6 +4858,14 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-path": {
@@ -3695,6 +4904,12 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
 		"object-copy": {
@@ -3755,14 +4970,50 @@
 				"isobject": "^3.0.0"
 			}
 		},
-		"object.getownpropertydescriptors": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.entries": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+			"integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
+		"object.fromentries": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+			"integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"object.pick": {
@@ -3774,6 +5025,18 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"object.values": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+			"integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3783,6 +5046,21 @@
 				"wrappy": "1"
 			}
 		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			}
+		},
+		"opencollective-postinstall": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+			"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+			"dev": true
+		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -3791,14 +5069,6 @@
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.10",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-					"dev": true
-				}
 			}
 		},
 		"optionator": {
@@ -3814,6 +5084,12 @@
 				"type-check": "~0.3.2",
 				"word-wrap": "~1.2.3"
 			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"p-each-series": {
 			"version": "1.0.0",
@@ -3831,21 +5107,21 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "^2.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-reduce": {
@@ -3855,19 +5131,27 @@
 			"dev": true
 		},
 		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
 		},
-		"parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
+				"callsites": "^3.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse5": {
@@ -3896,6 +5180,12 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -3909,20 +5199,12 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
+				"pify": "^2.0.0"
 			}
 		},
 		"performance-now": {
@@ -3932,9 +5214,9 @@
 			"dev": true
 		},
 		"pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 			"dev": true
 		},
 		"pirates": {
@@ -3947,12 +5229,21 @@
 			}
 		},
 		"pkg-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0"
+				"find-up": "^2.1.0"
+			}
+		},
+		"please-upgrade-node": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+			"dev": true,
+			"requires": {
+				"semver-compare": "^1.0.0"
 			}
 		},
 		"pn": {
@@ -3973,6 +5264,161 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
+		"prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+			"dev": true
+		},
+		"prettier-eslint": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.1.tgz",
+			"integrity": "sha512-KZT65QTosSAqBBqmrC+RpXbsMRe7Os2YSR9cAfFbDlyPAopzA/S5bioiZ3rpziNQNSJaOxmtXSx07EQ+o2Dlug==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/parser": "^1.10.2",
+				"common-tags": "^1.4.0",
+				"core-js": "^3.1.4",
+				"dlv": "^1.1.0",
+				"eslint": "^5.0.0",
+				"indent-string": "^4.0.0",
+				"lodash.merge": "^4.6.0",
+				"loglevel-colored-level-prefix": "^1.0.0",
+				"prettier": "^1.7.0",
+				"pretty-format": "^23.0.1",
+				"require-relative": "^0.8.7",
+				"typescript": "^3.2.1",
+				"vue-eslint-parser": "^2.0.2"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+					"integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"eslint": {
+					"version": "5.16.0",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+					"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"ajv": "^6.9.1",
+						"chalk": "^2.1.0",
+						"cross-spawn": "^6.0.5",
+						"debug": "^4.0.1",
+						"doctrine": "^3.0.0",
+						"eslint-scope": "^4.0.3",
+						"eslint-utils": "^1.3.1",
+						"eslint-visitor-keys": "^1.0.0",
+						"espree": "^5.0.1",
+						"esquery": "^1.0.1",
+						"esutils": "^2.0.2",
+						"file-entry-cache": "^5.0.1",
+						"functional-red-black-tree": "^1.0.1",
+						"glob": "^7.1.2",
+						"globals": "^11.7.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.0.0",
+						"imurmurhash": "^0.1.4",
+						"inquirer": "^6.2.2",
+						"js-yaml": "^3.13.0",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.3.0",
+						"lodash": "^4.17.11",
+						"minimatch": "^3.0.4",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.8.2",
+						"path-is-inside": "^1.0.2",
+						"progress": "^2.0.0",
+						"regexpp": "^2.0.1",
+						"semver": "^5.5.1",
+						"strip-ansi": "^4.0.0",
+						"strip-json-comments": "^2.0.1",
+						"table": "^5.2.3",
+						"text-table": "^0.2.0"
+					}
+				},
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"espree": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+					"dev": true,
+					"requires": {
+						"acorn": "^6.0.7",
+						"acorn-jsx": "^5.0.0",
+						"eslint-visitor-keys": "^1.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
+				}
+			}
+		},
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"dev": true,
+			"requires": {
+				"fast-diff": "^1.1.2"
+			}
+		},
 		"pretty-format": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
@@ -3983,7 +5429,21 @@
 				"ansi-regex": "^4.0.0",
 				"ansi-styles": "^3.2.0",
 				"react-is": "^16.8.4"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				}
 			}
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
 		},
 		"prompts": {
 			"version": "2.3.0",
@@ -3993,6 +5453,17 @@
 			"requires": {
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.3"
+			}
+		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
 			}
 		},
 		"psl": {
@@ -4012,10 +5483,9 @@
 			}
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -4035,24 +5505,34 @@
 			"dev": true
 		},
 		"read-pkg": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^4.0.0",
+				"load-json-file": "^2.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
+				"path-type": "^2.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0",
-				"read-pkg": "^3.0.0"
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+			"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -4064,6 +5544,12 @@
 				"util.promisify": "^1.0.0"
 			}
 		},
+		"regenerator-runtime": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+			"dev": true
+		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4073,6 +5559,12 @@
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
 			}
+		},
+		"regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -4120,17 +5612,6 @@
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
-				"form-data": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-					"dev": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				},
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -4181,6 +5662,12 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
+		"require-relative": {
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
@@ -4197,12 +5684,20 @@
 			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
 			}
 		},
 		"resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
 		},
 		"resolve-url": {
@@ -4211,6 +5706,16 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -4218,9 +5723,9 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
@@ -4232,10 +5737,34 @@
 			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
 			"dev": true
 		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "^2.1.0"
+			}
+		},
+		"run-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+			"integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+			"dev": true
+		},
+		"rxjs": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
 		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -4266,17 +5795,31 @@
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+			"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
+		},
+		"semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
 			"dev": true
 		},
 		"set-blocking": {
@@ -4347,10 +5890,21 @@
 			"dev": true
 		},
 		"slash": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
+		},
+		"slice-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"astral-regex": "^1.0.0",
+				"is-fullwidth-code-point": "^2.0.0"
+			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -4394,12 +5948,6 @@
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
@@ -4562,6 +6110,12 @@
 				"extend-shallow": "^3.0.0"
 			}
 		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
 		"sshpk": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -4622,12 +6176,6 @@
 				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -4640,14 +6188,24 @@
 			}
 		},
 		"string-width": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^5.1.0"
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string.prototype.trimleft": {
@@ -4671,11 +6229,11 @@
 			}
 		},
 		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"strip-ansi": {
@@ -4685,6 +6243,14 @@
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				}
 			}
 		},
 		"strip-bom": {
@@ -4697,6 +6263,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
 			"dev": true
 		},
 		"superb": {
@@ -4722,6 +6294,31 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
+		"table": {
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
+			}
+		},
 		"test-exclude": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -4732,13 +6329,137 @@
 				"minimatch": "^3.0.4",
 				"read-pkg-up": "^4.0.0",
 				"require-main-filename": "^2.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				}
 			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -4808,6 +6529,14 @@
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				}
 			}
 		},
 		"tr46": {
@@ -4817,7 +6546,21 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				}
 			}
+		},
+		"tslib": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -4842,6 +6585,18 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
+		},
+		"type-fest": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+			"integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+			"dev": true
 		},
 		"uglify-js": {
 			"version": "3.7.2",
@@ -4926,6 +6681,14 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				}
 			}
 		},
 		"urix": {
@@ -4941,13 +6704,6 @@
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-				}
 			}
 		},
 		"use": {
@@ -4972,9 +6728,14 @@
 			}
 		},
 		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+		},
+		"v8-compile-cache": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -4996,6 +6757,65 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			}
+		},
+		"vue-eslint-parser": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
+			"integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.2",
+				"esquery": "^1.0.0",
+				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+					"dev": true
+				},
+				"acorn-jsx": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+					"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+					"dev": true,
+					"requires": {
+						"acorn": "^3.0.4"
+					},
+					"dependencies": {
+						"acorn": {
+							"version": "3.3.0",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+							"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+							"dev": true
+						}
+					}
+				},
+				"eslint-scope": {
+					"version": "3.7.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+					"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"espree": {
+					"version": "3.5.4",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+					"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+					"dev": true,
+					"requires": {
+						"acorn": "^5.5.0",
+						"acorn-jsx": "^3.0.0"
+					}
+				}
 			}
 		},
 		"w3c-hr-time": {
@@ -5089,6 +6909,19 @@
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
 				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -5096,6 +6929,15 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"write": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
 		},
 		"write-file-atomic": {
 			"version": "2.4.1",
@@ -5159,6 +7001,62 @@
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
 				"yargs-parser": "^13.1.1"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"test": "npm run lint && jest",
 		"deploy:dev": "npm run test && serverless deploy -v --stage dev",
 		"deploy:prod": "npm run test && serverless deploy -v --stage prod",
-		"logs": "serverless logs --function runWerdino --tail",
-		"invoke:local": "SLS_DEBUG=* serverless invoke local --function runWerdino",
+		"logs": "serverless logs --function run --tail",
+		"invoke:local": "SLS_DEBUG=* serverless invoke local --function run",
 		"lint": "eslint . --ignore-path .gitignore --ext .js",
 		"fix": "eslint . --ext .js --fix"
 	},

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "werdino-daily-slack",
-	"version": "2.0.0",
-	"description": "The Werdino daily menu in English and German, delivered straight to Slack via AWS Lambda",
+	"name": "tx-chef",
+	"version": "3.0.0",
+	"description": "Tamedia daily menus in English and German, delivered straight to Slack via AWS Lambda",
 	"license": "MIT",
-	"repository": "https://github.com/radiovisual/werdino-daily-slack",
+	"repository": "https://github.com/tamediadigital/tx-chef",
 	"author": {
 		"name": "Michael Wuergler",
 		"email": "wuergler@gmail.com",
@@ -13,11 +13,13 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "jest",
+		"test": "npm run lint && jest",
 		"deploy:dev": "npm run test && serverless deploy -v --stage dev",
 		"deploy:prod": "npm run test && serverless deploy -v --stage prod",
 		"logs": "serverless logs --function runWerdino --tail",
-		"invoke:local": "SLS_DEBUG=* serverless invoke local --function runWerdino"
+		"invoke:local": "SLS_DEBUG=* serverless invoke local --function runWerdino",
+		"lint": "eslint . --ignore-path .gitignore --ext .js",
+		"fix": "eslint . --ext .js --fix"
 	},
 	"files": [
 		"index.js",
@@ -27,6 +29,7 @@
 	],
 	"keywords": [
 		"werdino",
+		"tamedia",
 		"english",
 		"german",
 		"serverless",
@@ -42,6 +45,24 @@
 		"superb": "^3.0.0"
 	},
 	"devDependencies": {
-		"jest": "^24.5.0"
+		"eslint": "6.3.0",
+		"eslint-config-airbnb": "18.0.1",
+		"eslint-config-airbnb-base": "^14.0.0",
+		"eslint-config-prettier": "6.2.0",
+		"eslint-plugin-import": "2.18.2",
+		"eslint-plugin-jest": "22.16.0",
+		"eslint-plugin-jsx-a11y": "^6.2.3",
+		"eslint-plugin-prettier": "3.1.0",
+		"eslint-plugin-react": "^7.17.0",
+		"husky": "^3.1.0",
+		"jest": "^24.5.0",
+		"prettier": "^1.18.2",
+		"prettier-eslint": "^9.0.1"
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "npm run lint",
+			"pre-push": "npm run test"
+		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,7 @@
 
 # TX Chef
 
-https://github.com/tamediadigital/tx-chef/workflows/build/badge.svg
-
-:pizza: :hamburger: 
+![](https://github.com/tamediadigital/tx-chef/workflows/build/badge.svg) :pizza: :hamburger: 
 
 > The Daily menus for [Werdino](https://clients.eurest.ch/de/tamediazuerich/menu), [Bubenberg](https://clients.eurest.ch/dzz/de/Bubenberg), [Bern Zentweg](https://www.eurest.ch/dzb), [Bussigny](https://www.eurest.ch/cil), [Le Scoop](https://www.eurest.ch/tamedia-lausanne) and [BKW Atrium](https://bkw-bern.sv-restaurant.ch/de/menuplan) translated to English and delivered straight to Slack via AWS Lambda
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,8 @@
 
 :pizza: :hamburger: 
 
-> The [Werdino daily menu](https://clients.eurest.ch/de/tamediazuerich/menu) and the [Bubenberg daily menu](https://clients.eurest.ch/dzz/de/Bubenberg) in English and German, delivered straight to Slack via AWS Lambda
+> The Daily menus for [Werdino](https://clients.eurest.ch/de/tamediazuerich/menu), [Bubenberg](https://clients.eurest.ch/dzz/de/Bubenberg), [Bern Zentweg](https://www.eurest.ch/dzb), [Bussigny](https://www.eurest.ch/cil), [Le Scoop](https://www.eurest.ch/tamedia-lausanne) and [BKW Atrium](https://bkw-bern.sv-restaurant.ch/de/menuplan) translated to English and delivered straight to Slack via AWS Lambda
+
 
 :trophy:
 
@@ -28,12 +29,16 @@
 ```
 3. Save two files named `config/config.dev.json` and `config.prod.json` with the following structure:
 
-:bulb: **Note:** You can have more than one webhook assigned for Werdino or Bubenberg, you just need to seperate the multiple webhook addresses with a comma
+:bulb: **Note:** You can have more than one webhook assigned, you just need to seperate the multiple webhook addresses with a comma
 
 ```
 {
-  "WERDINO_WEBHOOK_ADDRESSES": "<COMMA_DELIMITED_WEBHOOK_ADDRESSES>",
-  "BUBENBERG_WEBHOOK_ADDRESSES": "<COMMA_DELIMITED_WEBHOOK_ADDRESSES>"
+  "WERDINO_WEBHOOK_ADDRESSES": "https://hooks.slack.com/services/...",
+  "BUBENBERG_WEBHOOK_ADDRESSES": "https://hooks.slack.com/services/...",
+  "BERN_ZENTWEG_WEBHOOK_ADDRESSES": "https://hooks.slack.com/services/...",
+	"BUSSIGNY_WEBHOOK_ADDRESSES": "https://hooks.slack.com/services/...",
+	"LE_SCOOP_WEBHOOK_ADDRESSES": "https://hooks.slack.com/services/...",
+	"BKW_ATRIUM_WEBHOOK_ADDRESSES": "https://hooks.slack.com/services/..."
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # TX Chef
 
-https://github.com/tamediadigital/tx-chef/workflows/CI/badge.svg
+![](https://github.com/tamediadigital/tx-chef/workflows/CI/badge.svg)
 
 :pizza: :hamburger: 
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # TX Chef
 
-![](https://github.com/tamediadigital/tx-chef/workflows/CI/badge.svg)
+https://github.com/tamediadigital/tx-chef/workflows/build/badge.svg
 
 :pizza: :hamburger: 
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 # TX Chef
 
+https://github.com/tamediadigital/tx-chef/workflows/CI/badge.svg
+
 :pizza: :hamburger: 
 
 > The Daily menus for [Werdino](https://clients.eurest.ch/de/tamediazuerich/menu), [Bubenberg](https://clients.eurest.ch/dzz/de/Bubenberg), [Bern Zentweg](https://www.eurest.ch/dzb), [Bussigny](https://www.eurest.ch/cil), [Le Scoop](https://www.eurest.ch/tamedia-lausanne) and [BKW Atrium](https://bkw-bern.sv-restaurant.ch/de/menuplan) translated to English and delivered straight to Slack via AWS Lambda

--- a/readme.md
+++ b/readme.md
@@ -54,14 +54,14 @@ $ serverless deploy --stage prod
 ### Reading the Logs
 
 ```
-$ serverless logs --function runWerdino --tail
+$ serverless logs --function run --tail
 ```
 
 ### Deploy the Function Locally for Testing
 
 :bulb: Running locally will apply the `dev` stage by default
 ```
-SLS_DEBUG=* serverless invoke local --function runWerdino --stage dev
+SLS_DEBUG=* serverless invoke local --function run --stage dev
 ```
 
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,7 +3,7 @@ provider:
   name: aws
   profile: tamedia
   region: us-east-2
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   role: arn:aws:iam::716110578696:role/service-role/info-werdino-lambda-role-gfqzye3q
 functions:

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ provider:
   role: arn:aws:iam::716110578696:role/service-role/info-werdino-lambda-role-gfqzye3q
 functions:
   runWerdino:
-    handler: handler.runWerdino
+    handler: handler.run
     environment:
       WERDINO_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):WERDINO_WEBHOOK_ADDRESSES}
       BUBENBERG_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):BUBENBERG_WEBHOOK_ADDRESSES}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,13 +1,13 @@
-service: tx-chef-lambda
+service: tx-chef
 provider:
   name: aws
   profile: tamedia
-  region: us-east-2
+  region: eu-central-1
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   role: arn:aws:iam::716110578696:role/service-role/info-werdino-lambda-role-gfqzye3q
 functions:
-  runWerdino:
+  run:
     handler: handler.run
     environment:
       WERDINO_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):WERDINO_WEBHOOK_ADDRESSES}

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,7 +12,10 @@ functions:
     environment:
       WERDINO_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):WERDINO_WEBHOOK_ADDRESSES}
       BUBENBERG_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):BUBENBERG_WEBHOOK_ADDRESSES}
-      GOOGLE_APPLICATION_CREDENTIALS: ${file(./config/config.${self:provider.stage, }.json):GOOGLE_APPLICATION_CREDENTIALS}
+      BERN_ZENTWEG_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):BERN_ZENTWEG_WEBHOOK_ADDRESSES}
+      BUSSIGNY_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):BUSSIGNY_WEBHOOK_ADDRESSES}
+      LE_SCOOP_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):LE_SCOOP_WEBHOOK_ADDRESSES}
+      BKW_ATRIUM_WEBHOOK_ADDRESSES: ${file(./config/config.${self:provider.stage, }.json):BKW_ATRIUM_WEBHOOK_ADDRESSES}
     events:
     - schedule:
         rate: cron(0 5 ? * MON-FRI *)


### PR DESCRIPTION
- [x] Adds the new menus for other TX locations
- [x] Adds unit tests
- [x] Adds the new page scraping routines for the BKW Atrium page
- [x] Removes unused Google Cloud references
- [x] Updated the messageBuilder routine to ignore adding section headers where they are not needed
- [x] Added the ability to supply the target language (so we can tell AWS Translate which language to translate _from_)
- [x] Updates references to `werdino` to be more the more universal: `eurest`
- [x] Minor refactors 
- [x] Adds linting rules
- [x] Adds GitHub Actions to run tests and linter in CI
- [x] Adds a build badge to the Readme